### PR TITLE
Add Instructions to start SoftEther VPN at boot as unit.d service

### DIFF
--- a/events/2020.06.Online/tools/vpn_softetherbridge.md
+++ b/events/2020.06.Online/tools/vpn_softetherbridge.md
@@ -127,7 +127,7 @@ then setting up an `init.d` service file.  However the instructions for the serv
 quite right for the Raspberry Pi which does not have `chkconfig`.
 Instead you have to 
 manually set the dependencies in the service file (see here for an appropriate 
-[init.d/vpnbridge service file](vpnbridge) and then use the following to 
+[init.d/vpnbridge service file](vpnbridge)) and then use the following to 
 make it executable and register it:
 ```
    sudo chmod +x /etc/init.d/vpnbridge
@@ -144,5 +144,11 @@ bridge creation to `/etc/network/interfaces`, but the Raspberry Pi makes this co
 that file from a DHCP configuration file...
 A simpler if slightly hacky solution is to add the 
 bridge creation commands to the `init.d` script, which is what I have done above.
-Note that I use `eth1` for my external (downstream) interface, so you might have to edit that part to
-make it work for your interfaces.
+
+Note that I use `eth0` for my connection to the upstream external network (internet) and
+`eth1` for my downstream (local) VLAN interface, so you might have to edit that part to
+make it work for your interfaces.  For example, you might be using `wlan0` for your upstream network
+and `eth0` for your downstream network instead.  In addition the static route command is included
+in this service file but if the IP of the VPN server changes that part will have to be changed,
+and also your local gateway may have a different address than what I used.  In short, make sure to
+check and edit these elements.

--- a/events/2020.06.Online/tools/vpn_softetherbridge.md
+++ b/events/2020.06.Online/tools/vpn_softetherbridge.md
@@ -115,3 +115,33 @@ then bridge the tap interface and physical interface (`eth0`) using:
 You may adjust DHCP setting for physical interfaces.
 
 Further information about local bridge is [here](https://www.softether.org/4-docs/1-manual/3._SoftEther_VPN_Server_Manual/3.6_Local_Bridges#3.6.11_Points_to_Note_when_Local_Bridging_in_Linux.2C_FreeBSD.2C_Solaris_or_Mac_OS_X).
+
+## Automatically starting at boot
+The local VPN bridge software automatically saves its configuration in a file (`vpn_bridge.config`, owned by root) so
+you do not have to reconfigure it each time you run it.
+If you set it up to run in 
+["service mode"](https://www.softether.org/4-docs/1-manual/7._Installing_SoftEther_VPN_Server/7.3_Install_on_Linux_and_Initial_Configurations) 
+then it will also run automatically at boot using `init.d`.
+This starts by copying the files to `/usr/local` and making them owned by root,
+then setting up an `init.d` service file.  However the instructions for the service file are not
+quite right for the Raspberry Pi which does not have `chkconfig`.
+Instead you have to 
+manually set the dependencies in the service file (see here for an appropriate 
+[init.d/vpnbridge service file](vpnbridge) and then use the following to 
+make it executable and register it:
+```
+   sudo chmod +x /etc/init.d/vpnbridge
+   sudo update-rc.d vpnbridge defaults
+```
+
+As a secondary problem,
+if you want to use a bridge interface (see `br0` above) then you have to make the 
+`br0` interface persistent.  This is a bit tricky since `br0` depends on the
+`tap_svpn` interface which
+is actually dynamically created by `vpnbridge` when it starts.
+One way around this is to add the 
+bridge creation to `/etc/network/interfaces`.
+However a simpler solution is to add the 
+bridge creation commands to the `init.d` script, which is what I have done above.
+Note that I use `eth1` for my external (downstream) interface, so you might have to edit that part to
+make it work for your interfaces.

--- a/events/2020.06.Online/tools/vpn_softetherbridge.md
+++ b/events/2020.06.Online/tools/vpn_softetherbridge.md
@@ -140,8 +140,9 @@ if you want to use a bridge interface (see `br0` above) then you have to make th
 `tap_svpn` interface which
 is actually dynamically created by `vpnbridge` when it starts.
 One way around this is to add the 
-bridge creation to `/etc/network/interfaces`.
-However a simpler solution is to add the 
+bridge creation to `/etc/network/interfaces`, but the Raspberry Pi makes this complicated by autogenerating 
+that file from a DHCP configuration file...
+A simpler if slightly hacky solution is to add the 
 bridge creation commands to the `init.d` script, which is what I have done above.
 Note that I use `eth1` for my external (downstream) interface, so you might have to edit that part to
 make it work for your interfaces.

--- a/events/2020.06.Online/tools/vpnbridge
+++ b/events/2020.06.Online/tools/vpnbridge
@@ -16,6 +16,7 @@ LOCK=/var/lock/subsys/vpnbridge
 test -x $DAEMON || exit 0
 case "$1" in
 start)
+ip route add 52.38.92.17 via 192.168.2.1 dev eth0
 $DAEMON start
 touch $LOCK
 sleep 5

--- a/events/2020.06.Online/tools/vpnbridge
+++ b/events/2020.06.Online/tools/vpnbridge
@@ -1,0 +1,57 @@
+#!/bin/sh
+#
+### BEGIN INIT INFO
+# Provides:          vpnbridge
+# Required-Start:    $remote_fs $local_fs $syslog $networking
+# Required-Stop:     $remote_fs $local_fs $syslog
+# Should-Start:
+# Should-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: SoftEther VPN Bridge
+# Description:
+### END INIT INFO
+DAEMON=/usr/local/vpnbridge/vpnbridge
+LOCK=/var/lock/subsys/vpnbridge
+test -x $DAEMON || exit 0
+case "$1" in
+start)
+$DAEMON start
+touch $LOCK
+sleep 5
+brctl addbr br0
+ip link set eth1 down
+ip addr add 0.0.0.0/24 dev eth1
+brctl addif br0 tap_svpn
+brctl addif br0 eth1
+ip link set br0 up
+ip link set eth1 up
+dhclient br0
+;;
+stop)
+ip link set br0 down
+brctl delbr br0
+$DAEMON stop
+rm $LOCK
+;;
+restart)
+ip link set br0 down
+brctl delbr br0
+$DAEMON stop
+sleep 3
+$DAEMON start
+sleep 5
+brctl addbr br0
+ip link set eth1 down
+ip addr add 0.0.0.0/24 dev eth1
+brctl addif br0 tap_svpn
+brctl addif br0 eth1
+ip link set br0 up
+ip link set eth1 up
+dhclient br0
+;;
+*)
+echo "Usage: $0 {start|stop|restart}"
+exit 1
+esac
+exit 0

--- a/events/2020.06.Online/tools/vpnbridge
+++ b/events/2020.06.Online/tools/vpnbridge
@@ -17,16 +17,17 @@ test -x $DAEMON || exit 0
 case "$1" in
 start)
 ip route add 52.38.92.17 via 192.168.2.1 dev eth0
+ip link set eth1 down
+ip addr add 0.0.0.0/24 dev eth1
+ip link set eth1 up
 $DAEMON start
 touch $LOCK
 sleep 5
 brctl addbr br0
-ip link set eth1 down
-# ip addr add 0.0.0.0/24 dev eth1
 brctl addif br0 tap_svpn
+sleep 5
 brctl addif br0 eth1
 ip link set br0 up
-ip link set eth1 up
 dhclient br0
 ;;
 stop)
@@ -40,15 +41,16 @@ ip link set br0 down
 brctl delbr br0
 $DAEMON stop
 sleep 3
+ip link set eth1 down
+ip addr add 0.0.0.0/24 dev eth1
+ip link set eth1 up
 $DAEMON start
 sleep 5
 brctl addbr br0
-ip link set eth1 down
-# ip addr add 0.0.0.0/24 dev eth1
 brctl addif br0 tap_svpn
+sleep 5
 brctl addif br0 eth1
 ip link set br0 up
-ip link set eth1 up
 dhclient br0
 ;;
 *)

--- a/events/2020.06.Online/tools/vpnbridge
+++ b/events/2020.06.Online/tools/vpnbridge
@@ -17,15 +17,15 @@ test -x $DAEMON || exit 0
 case "$1" in
 start)
 ip route add 52.38.92.17 via 192.168.2.1 dev eth0
-ip link set eth1 down
-ip addr add 0.0.0.0/24 dev eth1
-ip link set eth1 up
+#ip link set eth1 down
+#ip addr add 0.0.0.0/24 dev eth1
+#ip link set eth1 up
 $DAEMON start
 touch $LOCK
 sleep 5
 brctl addbr br0
 brctl addif br0 tap_svpn
-sleep 5
+sleep 10
 brctl addif br0 eth1
 ip link set br0 up
 dhclient br0
@@ -41,14 +41,14 @@ ip link set br0 down
 brctl delbr br0
 $DAEMON stop
 sleep 3
-ip link set eth1 down
-ip addr add 0.0.0.0/24 dev eth1
-ip link set eth1 up
+#ip link set eth1 down
+#ip addr add 0.0.0.0/24 dev eth1
+#ip link set eth1 up
 $DAEMON start
 sleep 5
 brctl addbr br0
 brctl addif br0 tap_svpn
-sleep 5
+sleep 10
 brctl addif br0 eth1
 ip link set br0 up
 dhclient br0

--- a/events/2020.06.Online/tools/vpnbridge
+++ b/events/2020.06.Online/tools/vpnbridge
@@ -22,7 +22,7 @@ touch $LOCK
 sleep 5
 brctl addbr br0
 ip link set eth1 down
-ip addr add 0.0.0.0/24 dev eth1
+# ip addr add 0.0.0.0/24 dev eth1
 brctl addif br0 tap_svpn
 brctl addif br0 eth1
 ip link set br0 up
@@ -44,7 +44,7 @@ $DAEMON start
 sleep 5
 brctl addbr br0
 ip link set eth1 down
-ip addr add 0.0.0.0/24 dev eth1
+# ip addr add 0.0.0.0/24 dev eth1
 brctl addif br0 tap_svpn
 brctl addif br0 eth1
 ip link set br0 up


### PR DESCRIPTION
Add instructions for how to make the VPN bridge autostart.   This includes a "sample" init.d file (tools/vpnbridge) that can be edited to match a local configuration (and is adapted to Raspbian on the Raspberry Pi; the instructions for SoftEther are for a slightly different variant of Linux...).