### PR TITLE
Add converted SDF models as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "tools/thingweb-playground"]
 	path = tools/thingweb-playground
 	url = https://github.com/thingweb/thingweb-playground
+[submodule "events/2021.09.Online/TD/TMs/U Bremen"]
+	path = events/2021.09.Online/TD/TMs/U Bremen
+	url = https://github.com/JKRhb/onedm-playground-wot-tm.git


### PR DESCRIPTION
This PR adds SDF models from the [oneDM playground](https://github.com/one-data-model/playground) to the plugfest directory which have been converted to TMs using my [sdf-wot-converter](https://github.com/JKRhb/sdf-wot-converter-py). For reducing redundancy, I added the models as a submodule pointing to a [separate repository](https://github.com/JKRhb/onedm-playground-wot-tm) but if it would be better to include them directly (e. g. for testing) I could do so as well :) Just let me know which solution would be better.