### PR TITLE
Fujitsu TDs

### DIFF
--- a/events/2022.03.Online/TD/Fujitsu/TDs/fjsensor.td.jsonld
+++ b/events/2022.03.Online/TD/Fujitsu/TDs/fjsensor.td.jsonld
@@ -1,0 +1,57 @@
+{
+  "@context": [
+    "https://www.w3.org/2019/wot/td/v1",
+    "https://www.w3.org/2022/wot/td/v1.1"
+  ],
+  "@type": "Thing",
+  "title": "Fujitsu-sensor",
+  "id": "urn:com:fujitsu:sensor01",
+  "description": "sensors with wifi interface",
+  "version": "1.0.0",
+  "created": "2022-03-11T12:00:00+09:00",
+  "base": "http://192.168.1.174/things",
+  "securityDefinitions": {
+    "nosec_sc": {
+      "scheme": "nosec"
+    }
+  },
+  "security": "nosec_sc",
+  "properties": {
+    "temperature": {
+      "@type": "temperature",
+      "type": "number",
+      "readonly": true,
+      "observable": false,
+      "forms": [
+        {
+          "href": "properties/temperature",
+          "contentType": "application/json"
+        }
+      ]
+    },
+    "humidity": {
+      "@type": "humidity",
+      "type": "number",
+      "readonly": true,
+      "observable": false,
+      "forms": [
+        {
+          "href": "properties/humidity",
+          "contentType": "application/json"
+        }
+      ]
+    },
+    "airpressure": {
+      "@type": "airpressure",
+      "type": "number",
+      "readonly": true,
+      "observable": false,
+      "forms": [
+        {
+          "href": "properties/airpressure",
+          "contentType": "application/json"
+        }
+      ]
+    }
+  }
+}

--- a/events/2022.03.Online/TD/Fujitsu/TDs/fjsensor.td.jsonld
+++ b/events/2022.03.Online/TD/Fujitsu/TDs/fjsensor.td.jsonld
@@ -7,7 +7,9 @@
   "title": "Fujitsu-sensor",
   "id": "urn:com:fujitsu:sensor01",
   "description": "sensors with wifi interface",
-  "version": "1.0.0",
+  "version": {
+    "instance" : "1.0.0"
+  },
   "created": "2022-03-11T12:00:00+09:00",
   "base": "http://192.168.1.174/things",
   "securityDefinitions": {

--- a/events/2022.03.Online/TD/Fujitsu/prodecedByProxy/vfjsensor.td.jsonld
+++ b/events/2022.03.Online/TD/Fujitsu/prodecedByProxy/vfjsensor.td.jsonld
@@ -1,0 +1,60 @@
+{
+  "@type": "Thing",
+  "created": "2022-03-11T12:00:00+09:00",
+  "description": "sensors with wifi interface",
+  "title": "Fujitsu-sensor",
+  "@context": [
+    "https://www.w3.org/2019/wot/td/v1",
+    "https://www.w3.org/2022/wot/td/v1.1"
+  ],
+  "version": "1.0.0",
+  "security": "nosec_sc",
+  "modified": "2022-03-18T18:34:54+09:00",
+  "id": "urn:com:fujitsu:sensor01",
+  "securityDefinitions": {
+    "nosec_sc": {
+      "scheme": "nosec"
+    }
+  },
+  "actions": {},
+  "properties": {
+    "airpressure": {
+      "observable": false,
+      "type": "number",
+      "readonly": true,
+      "@type": "airpressure",
+      "forms": [
+        {
+          "href": "properties/airpressure",
+          "contentType": "application/json"
+        }
+      ]
+    },
+    "temperature": {
+      "observable": false,
+      "type": "number",
+      "readonly": true,
+      "@type": "temperature",
+      "forms": [
+        {
+          "href": "properties/temperature",
+          "contentType": "application/json"
+        }
+      ]
+    },
+    "humidity": {
+      "observable": false,
+      "type": "number",
+      "readonly": true,
+      "@type": "humidity",
+      "forms": [
+        {
+          "href": "properties/humidity",
+          "contentType": "application/json"
+        }
+      ]
+    }
+  },
+  "events": {},
+  "base": "http://192.168.30.130/Things/urn:com:fujitsu:sensor01"
+}

--- a/events/2022.03.Online/TD/Fujitsu/prodecedByProxy/vfjsensor.td.jsonld
+++ b/events/2022.03.Online/TD/Fujitsu/prodecedByProxy/vfjsensor.td.jsonld
@@ -7,7 +7,9 @@
     "https://www.w3.org/2019/wot/td/v1",
     "https://www.w3.org/2022/wot/td/v1.1"
   ],
-  "version": "1.0.0",
+  "version": {
+    "instance": "1.0.0"
+  },
   "security": "nosec_sc",
   "modified": "2022-03-18T18:34:54+09:00",
   "id": "urn:com:fujitsu:sensor01",

--- a/events/2022.03.Online/TD/Fujitsu/readme.md
+++ b/events/2022.03.Online/TD/Fujitsu/readme.md
@@ -1,0 +1,10 @@
+# Fujitsu contoribution
+## Sensor unit
+Fujitsu sensor unit equiped with temperature, humidity and air pressure sensors. This sensor unit is on our local network and invisible 
+because it's connected behindd the proxy.
+The TD under TD folder is the thing description of the real device. Discovery service is supported: Well-known URI and mDNS.
+
+## Proxy and Directory service for searching shadow
+Fujitsu proxy is working on VPN(192.168.30.130). The proxy rewrites the URL in TD to connect via the proxy without directly accessing 
+the device. The TD under porudecedByProxy folder is the thing description of the shodow.
+The proxy alos support a directory service for consumers to search the shadows produced inside the proxy. Discovery service is supported: mDNS.


### PR DESCRIPTION
Fujitsu connected a sensor unit and a proxy on VPN. TD of the real device and the shadow are added in TDs folder.