### PR TITLE
Fix validation errors

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -23,9 +23,12 @@ jobs:
         with:
           node-version: '15'       
       
-      - name: Install dependencies
-        working-directory: thingweb-playground/packages/cli
-        run: npm install
+      - name: Use lerna
+        run: npm install -g lerna
+      
+      - name: Bootstrap
+        working-directory: thingweb-playground
+        run: lerna bootstrap --no-ci
 
       - name: Run validation script on all new matching files
         env:


### PR DESCRIPTION
I have found the source of the problem. We have not pushed the new version of playground to npm yet. However, the github action pipeline is using that. With this PR, I am basing the script on the GitHub Master branch of the playground instead of npm version. I have already tested it at https://github.com/egekorkan/wot-testing/pull/2 