### PR TITLE
Intel - Home Assistant examples and README

### DIFF
--- a/events/2022.03.Online/TD/intel-wot-ha/README.md
+++ b/events/2022.03.Online/TD/intel-wot-ha/README.md
@@ -1,0 +1,47 @@
+# Intel - Online Testfest March 2022
+
+## Home Assistant Bridge
+Some TDs to access some test devices using the HTTP
+[Home Assistant REST API](link) as a bridge/gateway.
+These include:
+- A Shelly Door-Window 2. 
+- An ESPHome Grove device with multiple sensors and actuators.
+- An NCD RTD temperature sensor accessed via an MQTT bridge.
+- An RGBW LED Strip implemented using ESPHome.
+These are semi-automatically generated.  
+
+NOTE: In most cases not all the functionality
+is exposed (yet!). 
+
+Some of these devices support multiple sensors and actuators,
+but Home Assistant maps each sensor and actuator to a different "entity" and
+only some entities have been exposed.  
+
+In particular:
+- The Shelly sensor not only detects an open/close condition, 
+  but can also sense temperature, vibration,
+  tilt, illumination, and its own battery state.  
+  However, so far, only the 
+  "open-close" binary sensor has been exposed.  
+- The RGBW LED Strip is addressable and can be used to display data
+  as an ambient display. 
+  The current TDs only let you treat it as a single RGBW
+  light.
+- The ESPHome Grove device has temperature, humidity, a push button, a buzzer,
+  and an analog dial input.  It also computes several derived values, such
+  as dew point and altitude.  However, currently only temperature and
+  the analog dial are exposed.
+
+Also, currently only "states" are exposed (as properties) but not actions (which would
+map to "services" in Home Assistant) and events (which require use of a Web Socket
+protocol in Home Assistant).
+
+The structure of the Home Assistant data structures is also a little awkward when
+expressed in TDs.  In particular the Home Assistant RESTful API does not support
+different URLs for different sub-properties, instead it always returns the main
+property and all attributes in a single state object.  For example, the RGB light's
+main state is "on-off" but it has several other "attributes" like brightness, color, etc.
+
+If you want to access these Things for testing, please contact Michael McCool.
+Note that Home Assistant uses bearer tokens (but not OAuth) for access control.
+

--- a/events/2022.03.Online/TD/intel-wot-ha/binary_sensor.esp_grove_1_push_button_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/binary_sensor.esp_grove_1_push_button_2.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:715534d1-0545-4e17-8fc7-d65c5569be83",
+  "id": "urn:uuid:97ee35f9-e4ef-4663-be66-e4f97838478a",
   "title": "binary_sensor.esp_grove_1_push_button_2",
   "description": "esp_grove_1 Push Button",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:03:01.499Z",
+  "created": "2022-04-22T22:13:20.815Z",
   "properties": {
     "states": {
       "type": "object",
@@ -35,11 +35,11 @@
         },
         "last_changed": {
           "type": "string",
-          "format": "xsd:datetime"
+          "format": "date-time"
         },
         "last_updated": {
           "type": "string",
-          "format": "xsd:datetime"
+          "format": "date-time"
         },
         "context": {
           "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/binary_sensor.esp_grove_1_push_button_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/binary_sensor.esp_grove_1_push_button_2.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:882ca2e0-9dd3-4701-96a4-bfe78aaf43af",
+  "id": "urn:uuid:ecc578bc-b096-4e76-b207-f9fb06efff70",
   "title": "binary_sensor.esp_grove_1_push_button_2",
   "description": "esp_grove_1 Push Button",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:47:11.366Z",
+  "created": "2022-04-26T00:52:01.611Z",
   "properties": {
     "states": {
       "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/binary_sensor.esp_grove_1_push_button_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/binary_sensor.esp_grove_1_push_button_2.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:8667d3cf-db4e-4c5f-afc2-d0cfd33f268f",
+  "id": "urn:uuid:0abfef67-349d-42de-8ddf-2f5d742fc1cd",
   "title": "binary_sensor.esp_grove_1_push_button_2",
   "description": "esp_grove_1 Push Button",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:29:47.948Z",
+  "created": "2022-04-22T22:40:09.075Z",
   "properties": {
     "states": {
       "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/binary_sensor.esp_grove_1_push_button_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/binary_sensor.esp_grove_1_push_button_2.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:0abfef67-349d-42de-8ddf-2f5d742fc1cd",
+  "id": "urn:uuid:882ca2e0-9dd3-4701-96a4-bfe78aaf43af",
   "title": "binary_sensor.esp_grove_1_push_button_2",
   "description": "esp_grove_1 Push Button",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:40:09.075Z",
+  "created": "2022-04-22T22:47:11.366Z",
   "properties": {
     "states": {
       "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/binary_sensor.esp_grove_1_push_button_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/binary_sensor.esp_grove_1_push_button_2.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:19786f8b-36d8-43dc-b616-b35ec180f5c4",
+  "id": "urn:uuid:715534d1-0545-4e17-8fc7-d65c5569be83",
   "title": "binary_sensor.esp_grove_1_push_button_2",
   "description": "esp_grove_1 Push Button",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T16:55:09.479Z",
+  "created": "2022-04-22T22:03:01.499Z",
   "properties": {
     "states": {
       "type": "object",
@@ -70,9 +70,11 @@
           }
         }
       },
-      "form": {
-        "href": "states/binary_sensor.esp_grove_1_push_button_2"
-      }
+      "forms": [
+        {
+          "href": "states/binary_sensor.esp_grove_1_push_button_2"
+        }
+      ]
     }
   }
 }

--- a/events/2022.03.Online/TD/intel-wot-ha/binary_sensor.esp_grove_1_push_button_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/binary_sensor.esp_grove_1_push_button_2.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:97ee35f9-e4ef-4663-be66-e4f97838478a",
+  "id": "urn:uuid:8667d3cf-db4e-4c5f-afc2-d0cfd33f268f",
   "title": "binary_sensor.esp_grove_1_push_button_2",
   "description": "esp_grove_1 Push Button",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:13:20.815Z",
+  "created": "2022-04-22T22:29:47.948Z",
   "properties": {
     "states": {
       "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/binary_sensor.esp_grove_1_push_button_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/binary_sensor.esp_grove_1_push_button_2.td.jsonld
@@ -1,0 +1,78 @@
+{
+  "@context": [
+    "https://www.w3.org/2022/wot/td/v1.1"
+  ],
+  "base": "http://192.168.1.75:8123/api/",
+  "@type": "Thing",
+  "id": "urn:uuid:19786f8b-36d8-43dc-b616-b35ec180f5c4",
+  "title": "binary_sensor.esp_grove_1_push_button_2",
+  "description": "esp_grove_1 Push Button",
+  "securityDefinitions": {
+    "ha_sc": {
+      "scheme": "bearer"
+    }
+  },
+  "security": "ha_sc",
+  "created": "2022-04-22T16:55:09.479Z",
+  "properties": {
+    "states": {
+      "type": "object",
+      "properties": {
+        "entity_id": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "on",
+            "off"
+          ]
+        },
+        "attributes": {
+          "friendly_name": {
+            "type": "string"
+          }
+        },
+        "last_changed": {
+          "type": "string",
+          "format": "xsd:datetime"
+        },
+        "last_updated": {
+          "type": "string",
+          "format": "xsd:datetime"
+        },
+        "context": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "parent_id": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "user_id": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "form": {
+        "href": "states/binary_sensor.esp_grove_1_push_button_2"
+      }
+    }
+  }
+}

--- a/events/2022.03.Online/TD/intel-wot-ha/light.esp_rgbw_1_rgbw_strip.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/light.esp_rgbw_1_rgbw_strip.td.jsonld
@@ -1,0 +1,196 @@
+{
+  "@context": [
+    "https://www.w3.org/2022/wot/td/v1.1"
+  ],
+  "base": "http://192.168.1.75:8123/api/",
+  "@type": "Thing",
+  "id": "urn:uuid:bbdb86aa-d32a-4698-8eeb-7a6248fdb4f6",
+  "title": "light.esp_rgbw_1_rgbw_strip",
+  "description": "esp_rgbw_1 RGBW Strip",
+  "securityDefinitions": {
+    "ha_sc": {
+      "scheme": "bearer"
+    }
+  },
+  "security": "ha_sc",
+  "created": "2022-04-22T16:55:09.478Z",
+  "properties": {
+    "state": {
+      "type": "object",
+      "properties": {
+        "entity_id": "string",
+        "state": {
+          "type": "string",
+          "enum": [
+            "unavailable",
+            "on",
+            "off"
+          ]
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "effect_list": {
+              "type": "array",
+              "const": [
+                "Random",
+                "Custom Random",
+                "Custom Strobe",
+                "Pulse",
+                "Fast Pulse",
+                "Slow Pulse",
+                "Flicker",
+                "Custom Flicker",
+                "Rainbow",
+                "Custom Rainbow",
+                "Color Wipe",
+                "Custom Color Wipe",
+                "Scan",
+                "Custom Scan",
+                "Twinkle",
+                "Custom Addressable Twinkle",
+                "Random Twinkle",
+                "Custom Addressable Random Twinkle",
+                "Fireworks",
+                "Custom Fireworks",
+                "Addressable Flicker",
+                "Custom Addressable Flicker",
+                "Data Visualization",
+                "None"
+              ]
+            },
+            "supported_color_modes": {
+              "type": "array",
+              "const": [
+                "rgbw"
+              ]
+            },
+            "color_mode": {
+              "type": "string",
+              "const": "rgbw"
+            },
+            "brightness": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255
+            },
+            "hs_color": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 255
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "rgb_color": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 255
+              },
+              "minItems": 3,
+              "maxItems": 3
+            },
+            "rgbw_color": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 255
+              },
+              "minItems": 4,
+              "maxItems": 4
+            },
+            "xy_color": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 255
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "effect": {
+              "type": "string",
+              "enum": [
+                "Random",
+                "Custom Random",
+                "Custom Strobe",
+                "Pulse",
+                "Fast Pulse",
+                "Slow Pulse",
+                "Flicker",
+                "Custom Flicker",
+                "Rainbow",
+                "Custom Rainbow",
+                "Color Wipe",
+                "Custom Color Wipe",
+                "Scan",
+                "Custom Scan",
+                "Twinkle",
+                "Custom Addressable Twinkle",
+                "Random Twinkle",
+                "Custom Addressable Random Twinkle",
+                "Fireworks",
+                "Custom Fireworks",
+                "Addressable Flicker",
+                "Custom Addressable Flicker",
+                "Data Visualization",
+                "None"
+              ]
+            },
+            "friendly_name": {
+              "type": "string"
+            },
+            "supported_features": {
+              "type": "integer"
+            }
+          }
+        },
+        "last_changed": {
+          "type": "string",
+          "format": "xsd:datetime"
+        },
+        "last_updated": {
+          "type": "string",
+          "format": "xsd:datetime"
+        },
+        "context": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "parent_id": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "user_id": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "form": {
+        "href": "state/light.esp_rgbw_1_rgbw_strip"
+      }
+    }
+  }
+}

--- a/events/2022.03.Online/TD/intel-wot-ha/light.esp_rgbw_1_rgbw_strip.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/light.esp_rgbw_1_rgbw_strip.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:735811d2-a50b-42bd-9945-3c005063ad7b",
+  "id": "urn:uuid:191e59a0-a64d-4873-870b-5417758da5b4",
   "title": "light.esp_rgbw_1_rgbw_strip",
   "description": "esp_rgbw_1 RGBW Strip",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:03:01.497Z",
+  "created": "2022-04-22T22:13:20.814Z",
   "properties": {
     "state": {
       "type": "object",
@@ -153,11 +153,11 @@
         },
         "last_changed": {
           "type": "string",
-          "format": "xsd:datetime"
+          "format": "date-time"
         },
         "last_updated": {
           "type": "string",
-          "format": "xsd:datetime"
+          "format": "date-time"
         },
         "context": {
           "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/light.esp_rgbw_1_rgbw_strip.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/light.esp_rgbw_1_rgbw_strip.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:933e4868-6f5f-4366-a158-7338bcc12f94",
+  "id": "urn:uuid:5f2f7e2f-4c0f-4de6-89ae-7ebd46c01cdf",
   "title": "light.esp_rgbw_1_rgbw_strip",
   "description": "esp_rgbw_1 RGBW Strip",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:29:47.947Z",
+  "created": "2022-04-22T22:40:09.073Z",
   "properties": {
     "state": {
       "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/light.esp_rgbw_1_rgbw_strip.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/light.esp_rgbw_1_rgbw_strip.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:191e59a0-a64d-4873-870b-5417758da5b4",
+  "id": "urn:uuid:933e4868-6f5f-4366-a158-7338bcc12f94",
   "title": "light.esp_rgbw_1_rgbw_strip",
   "description": "esp_rgbw_1 RGBW Strip",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:13:20.814Z",
+  "created": "2022-04-22T22:29:47.947Z",
   "properties": {
     "state": {
       "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/light.esp_rgbw_1_rgbw_strip.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/light.esp_rgbw_1_rgbw_strip.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:5f2f7e2f-4c0f-4de6-89ae-7ebd46c01cdf",
+  "id": "urn:uuid:397c3b59-b22e-42df-86ae-5bd596c23aa5",
   "title": "light.esp_rgbw_1_rgbw_strip",
   "description": "esp_rgbw_1 RGBW Strip",
   "securityDefinitions": {
@@ -13,12 +13,14 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:40:09.073Z",
+  "created": "2022-04-22T22:47:11.365Z",
   "properties": {
     "state": {
       "type": "object",
       "properties": {
-        "entity_id": "string",
+        "entity_id": {
+          "type": "string"
+        },
         "state": {
           "type": "string",
           "enum": [

--- a/events/2022.03.Online/TD/intel-wot-ha/light.esp_rgbw_1_rgbw_strip.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/light.esp_rgbw_1_rgbw_strip.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:bbdb86aa-d32a-4698-8eeb-7a6248fdb4f6",
+  "id": "urn:uuid:735811d2-a50b-42bd-9945-3c005063ad7b",
   "title": "light.esp_rgbw_1_rgbw_strip",
   "description": "esp_rgbw_1 RGBW Strip",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T16:55:09.478Z",
+  "created": "2022-04-22T22:03:01.497Z",
   "properties": {
     "state": {
       "type": "object",
@@ -188,9 +188,11 @@
           }
         }
       },
-      "form": {
-        "href": "state/light.esp_rgbw_1_rgbw_strip"
-      }
+      "forms": [
+        {
+          "href": "state/light.esp_rgbw_1_rgbw_strip"
+        }
+      ]
     }
   }
 }

--- a/events/2022.03.Online/TD/intel-wot-ha/light.hue_color_lamp_1.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/light.hue_color_lamp_1.td.jsonld
@@ -4,16 +4,16 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:9100a2a9-1b7f-4837-8772-ab28161e064a",
-  "title": "light.esp_rgbw_1_rgbw_strip",
-  "description": "esp_rgbw_1 RGBW Strip",
+  "id": "urn:uuid:6c8af2a3-ffc8-4dff-9730-79e270bfe160",
+  "title": "light.hue_color_lamp_1",
+  "description": "Hue color lamp 1",
   "securityDefinitions": {
     "ha_sc": {
       "scheme": "bearer"
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-26T00:52:01.609Z",
+  "created": "2022-04-26T00:52:01.610Z",
   "properties": {
     "state": {
       "type": "object",
@@ -32,44 +32,24 @@
         "attributes": {
           "type": "object",
           "properties": {
-            "effect_list": {
-              "type": "array",
-              "const": [
-                "Random",
-                "Custom Random",
-                "Custom Strobe",
-                "Pulse",
-                "Fast Pulse",
-                "Slow Pulse",
-                "Flicker",
-                "Custom Flicker",
-                "Rainbow",
-                "Custom Rainbow",
-                "Color Wipe",
-                "Custom Color Wipe",
-                "Scan",
-                "Custom Scan",
-                "Twinkle",
-                "Custom Addressable Twinkle",
-                "Random Twinkle",
-                "Custom Addressable Random Twinkle",
-                "Fireworks",
-                "Custom Fireworks",
-                "Addressable Flicker",
-                "Custom Addressable Flicker",
-                "Data Visualization",
-                "None"
-              ]
+            "min_mireds": {
+              "type": "integer"
+            },
+            "max_mireds": {
+              "type": "integer"
             },
             "supported_color_modes": {
               "type": "array",
-              "const": [
-                "rgbw"
-              ]
+              "items": {
+                "type": "string"
+              }
             },
             "color_mode": {
               "type": "string",
-              "const": "rgbw"
+              "enum": [
+                "color_temp",
+                "xy"
+              ]
             },
             "brightness": {
               "type": "integer",
@@ -79,9 +59,7 @@
             "hs_color": {
               "type": "array",
               "items": {
-                "type": "integer",
-                "minimum": 0,
-                "maximum": 255
+                "type": "number"
               },
               "minItems": 2,
               "maxItems": 2
@@ -96,53 +74,24 @@
               "minItems": 3,
               "maxItems": 3
             },
-            "rgbw_color": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "minimum": 0,
-                "maximum": 255
-              },
-              "minItems": 4,
-              "maxItems": 4
-            },
             "xy_color": {
               "type": "array",
               "items": {
-                "type": "number",
-                "minimum": 0,
-                "maximum": 255
+                "type": "number"
               },
               "minItems": 2,
               "maxItems": 2
             },
-            "effect": {
+            "mode": {
               "type": "string",
               "enum": [
-                "Random",
-                "Custom Random",
-                "Custom Strobe",
-                "Pulse",
-                "Fast Pulse",
-                "Slow Pulse",
-                "Flicker",
-                "Custom Flicker",
-                "Rainbow",
-                "Custom Rainbow",
-                "Color Wipe",
-                "Custom Color Wipe",
-                "Scan",
-                "Custom Scan",
-                "Twinkle",
-                "Custom Addressable Twinkle",
-                "Random Twinkle",
-                "Custom Addressable Random Twinkle",
-                "Fireworks",
-                "Custom Fireworks",
-                "Addressable Flicker",
-                "Custom Addressable Flicker",
-                "Data Visualization",
-                "None"
+                "normal"
+              ]
+            },
+            "dynamics": {
+              "type": "string",
+              "enum": [
+                "none"
               ]
             },
             "friendly_name": {
@@ -192,7 +141,7 @@
       },
       "forms": [
         {
-          "href": "state/light.esp_rgbw_1_rgbw_strip"
+          "href": "state/light.hue_color_lamp_1"
         }
       ]
     }

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_dial_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_dial_2.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:bbd51c51-a42e-4ad6-93b5-9bc9a39c32d7",
+  "id": "urn:uuid:17574d7b-5fb0-4f48-9f95-e07106f0baf5",
   "title": "sensor.esp_grove_1_dial_2",
   "description": "esp_grove_1 Dial",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:47:11.366Z",
+  "created": "2022-04-26T00:52:01.610Z",
   "properties": {
     "states": {
       "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_dial_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_dial_2.td.jsonld
@@ -1,0 +1,85 @@
+{
+  "@context": [
+    "https://www.w3.org/2022/wot/td/v1.1"
+  ],
+  "base": "http://192.168.1.75:8123/api/",
+  "@type": "Thing",
+  "id": "urn:uuid:d3b47a0e-fdf5-4ac0-b6c0-0a165071e68a",
+  "title": "sensor.esp_grove_1_dial_2",
+  "description": "esp_grove_1 Dial",
+  "securityDefinitions": {
+    "ha_sc": {
+      "scheme": "bearer"
+    }
+  },
+  "security": "ha_sc",
+  "created": "2022-04-22T16:55:09.479Z",
+  "properties": {
+    "states": {
+      "type": "object",
+      "properties": {
+        "entity_id": {
+          "type": "string"
+        },
+        "state": {
+          "type": "number"
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "state_class": {
+              "type": "string",
+              "const": "measurement"
+            },
+            "unit_of_measurement": {
+              "type": "string",
+              "const": "%"
+            },
+            "friendly_name": {
+              "type": "string"
+            }
+          }
+        },
+        "last_changed": {
+          "type": "string",
+          "format": "xsd:datetime"
+        },
+        "last_updated": {
+          "type": "string",
+          "format": "xsd:datetime"
+        },
+        "context": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "parent_id": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "user_id": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "form": {
+        "href": "states/sensor.esp_grove_1_dial_2"
+      }
+    }
+  }
+}

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_dial_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_dial_2.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:d3b47a0e-fdf5-4ac0-b6c0-0a165071e68a",
+  "id": "urn:uuid:31b2f51d-639b-497a-aa0d-55ad08c95d68",
   "title": "sensor.esp_grove_1_dial_2",
   "description": "esp_grove_1 Dial",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T16:55:09.479Z",
+  "created": "2022-04-22T22:03:01.498Z",
   "properties": {
     "states": {
       "type": "object",
@@ -77,9 +77,11 @@
           }
         }
       },
-      "form": {
-        "href": "states/sensor.esp_grove_1_dial_2"
-      }
+      "forms": [
+        {
+          "href": "states/sensor.esp_grove_1_dial_2"
+        }
+      ]
     }
   }
 }

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_dial_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_dial_2.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:61ce6be2-f651-44d3-a270-c4bb1ff5e014",
+  "id": "urn:uuid:97bdba94-415f-436e-a2da-96e3f9c5543c",
   "title": "sensor.esp_grove_1_dial_2",
   "description": "esp_grove_1 Dial",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:13:20.815Z",
+  "created": "2022-04-22T22:29:47.948Z",
   "properties": {
     "states": {
       "type": "object",
@@ -33,7 +33,7 @@
             },
             "unit_of_measurement": {
               "type": "string",
-              "const": "%"
+              "const": "percent"
             },
             "friendly_name": {
               "type": "string"

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_dial_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_dial_2.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:95b99116-71c5-4831-80e1-63b821ae95ac",
+  "id": "urn:uuid:bbd51c51-a42e-4ad6-93b5-9bc9a39c32d7",
   "title": "sensor.esp_grove_1_dial_2",
   "description": "esp_grove_1 Dial",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:40:09.074Z",
+  "created": "2022-04-22T22:47:11.366Z",
   "properties": {
     "states": {
       "type": "object",
@@ -34,10 +34,6 @@
             "unit_of_measurement": {
               "type": "string",
               "const": "%"
-            },
-            "device_class": {
-              "type": "string",
-              "const": "none"
             },
             "friendly_name": {
               "type": "string"

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_dial_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_dial_2.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:31b2f51d-639b-497a-aa0d-55ad08c95d68",
+  "id": "urn:uuid:61ce6be2-f651-44d3-a270-c4bb1ff5e014",
   "title": "sensor.esp_grove_1_dial_2",
   "description": "esp_grove_1 Dial",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:03:01.498Z",
+  "created": "2022-04-22T22:13:20.815Z",
   "properties": {
     "states": {
       "type": "object",
@@ -42,11 +42,11 @@
         },
         "last_changed": {
           "type": "string",
-          "format": "xsd:datetime"
+          "format": "date-time"
         },
         "last_updated": {
           "type": "string",
-          "format": "xsd:datetime"
+          "format": "date-time"
         },
         "context": {
           "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_dial_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_dial_2.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:97bdba94-415f-436e-a2da-96e3f9c5543c",
+  "id": "urn:uuid:95b99116-71c5-4831-80e1-63b821ae95ac",
   "title": "sensor.esp_grove_1_dial_2",
   "description": "esp_grove_1 Dial",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:29:47.948Z",
+  "created": "2022-04-22T22:40:09.074Z",
   "properties": {
     "states": {
       "type": "object",
@@ -33,7 +33,11 @@
             },
             "unit_of_measurement": {
               "type": "string",
-              "const": "percent"
+              "const": "%"
+            },
+            "device_class": {
+              "type": "string",
+              "const": "none"
             },
             "friendly_name": {
               "type": "string"

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_temperature_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_temperature_2.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:e8761e37-a1e2-44b3-b3d0-1efa6c236563",
+  "id": "urn:uuid:a9dd57d3-5069-43ee-a6a0-a8bc1ae0d0c9",
   "title": "sensor.esp_grove_1_temperature_2",
   "description": "esp_grove_1 Temperature",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T16:55:09.478Z",
+  "created": "2022-04-22T22:03:01.498Z",
   "properties": {
     "states": {
       "type": "object",
@@ -81,9 +81,11 @@
           }
         }
       },
-      "form": {
-        "href": "states/sensor.esp_grove_1_temperature_2"
-      }
+      "forms": [
+        {
+          "href": "states/sensor.esp_grove_1_temperature_2"
+        }
+      ]
     }
   }
 }

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_temperature_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_temperature_2.td.jsonld
@@ -1,0 +1,89 @@
+{
+  "@context": [
+    "https://www.w3.org/2022/wot/td/v1.1"
+  ],
+  "base": "http://192.168.1.75:8123/api/",
+  "@type": "Thing",
+  "id": "urn:uuid:e8761e37-a1e2-44b3-b3d0-1efa6c236563",
+  "title": "sensor.esp_grove_1_temperature_2",
+  "description": "esp_grove_1 Temperature",
+  "securityDefinitions": {
+    "ha_sc": {
+      "scheme": "bearer"
+    }
+  },
+  "security": "ha_sc",
+  "created": "2022-04-22T16:55:09.478Z",
+  "properties": {
+    "states": {
+      "type": "object",
+      "properties": {
+        "entity_id": {
+          "type": "string"
+        },
+        "state": {
+          "type": "number"
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "state_class": {
+              "type": "string",
+              "const": "measurement"
+            },
+            "unit_of_measurement": {
+              "type": "string",
+              "const": "°C"
+            },
+            "device_class": {
+              "type": "string",
+              "const": "temperature"
+            },
+            "friendly_name": {
+              "type": "string"
+            }
+          }
+        },
+        "last_changed": {
+          "type": "string",
+          "format": "xsd:datetime"
+        },
+        "last_updated": {
+          "type": "string",
+          "format": "xsd:datetime"
+        },
+        "context": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "parent_id": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "user_id": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "form": {
+        "href": "states/sensor.esp_grove_1_temperature_2"
+      }
+    }
+  }
+}

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_temperature_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_temperature_2.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:df8d6999-78c9-4627-b29d-4cd8dce2ca4e",
+  "id": "urn:uuid:4eff1f35-6421-4e57-9e5a-7f61df4b44df",
   "title": "sensor.esp_grove_1_temperature_2",
   "description": "esp_grove_1 Temperature",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:29:47.947Z",
+  "created": "2022-04-22T22:40:09.074Z",
   "properties": {
     "states": {
       "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_temperature_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_temperature_2.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:7d12cfe4-77f5-4344-ae12-5ffbd1cbbd8f",
+  "id": "urn:uuid:daf12230-0ad1-4e23-90c9-5d2a88f917ff",
   "title": "sensor.esp_grove_1_temperature_2",
   "description": "esp_grove_1 Temperature",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:47:11.366Z",
+  "created": "2022-04-26T00:52:01.610Z",
   "properties": {
     "states": {
       "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_temperature_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_temperature_2.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:4eff1f35-6421-4e57-9e5a-7f61df4b44df",
+  "id": "urn:uuid:7d12cfe4-77f5-4344-ae12-5ffbd1cbbd8f",
   "title": "sensor.esp_grove_1_temperature_2",
   "description": "esp_grove_1 Temperature",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:40:09.074Z",
+  "created": "2022-04-22T22:47:11.366Z",
   "properties": {
     "states": {
       "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_temperature_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_temperature_2.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:459e8d3b-4cfc-4cd2-85ee-625ff7453832",
+  "id": "urn:uuid:df8d6999-78c9-4627-b29d-4cd8dce2ca4e",
   "title": "sensor.esp_grove_1_temperature_2",
   "description": "esp_grove_1 Temperature",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:13:20.814Z",
+  "created": "2022-04-22T22:29:47.947Z",
   "properties": {
     "states": {
       "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_temperature_2.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.esp_grove_1_temperature_2.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:a9dd57d3-5069-43ee-a6a0-a8bc1ae0d0c9",
+  "id": "urn:uuid:459e8d3b-4cfc-4cd2-85ee-625ff7453832",
   "title": "sensor.esp_grove_1_temperature_2",
   "description": "esp_grove_1 Temperature",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:03:01.498Z",
+  "created": "2022-04-22T22:13:20.814Z",
   "properties": {
     "states": {
       "type": "object",
@@ -46,11 +46,11 @@
         },
         "last_changed": {
           "type": "string",
-          "format": "xsd:datetime"
+          "format": "date-time"
         },
         "last_updated": {
           "type": "string",
-          "format": "xsd:datetime"
+          "format": "date-time"
         },
         "context": {
           "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.ncd1_temperature_1.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.ncd1_temperature_1.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:1ec8bbcf-6c47-48c6-9135-b3d0c356bc8c",
+  "id": "urn:uuid:d0d49af2-09fd-4b30-aed5-227e5140d0a8",
   "title": "sensor.ncd1_temperature_1",
   "description": "NCD1_Temperature_1",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:47:11.362Z",
+  "created": "2022-04-26T00:52:01.607Z",
   "properties": {
     "states": {
       "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.ncd1_temperature_1.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.ncd1_temperature_1.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:0dd8fbfa-20ae-421c-ab79-66aeefb02855",
+  "id": "urn:uuid:6c4449d8-8d0e-4df3-b1cd-45ce695bcac9",
   "title": "sensor.ncd1_temperature_1",
   "description": "NCD1_Temperature_1",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:03:01.495Z",
+  "created": "2022-04-22T22:13:20.811Z",
   "properties": {
     "states": {
       "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.ncd1_temperature_1.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.ncd1_temperature_1.td.jsonld
@@ -1,0 +1,82 @@
+{
+  "@context": [
+    "https://www.w3.org/2022/wot/td/v1.1"
+  ],
+  "base": "http://192.168.1.75:8123/api/",
+  "@type": "Thing",
+  "id": "urn:uuid:532f089d-8fff-406d-9809-37caa1571c37",
+  "title": "sensor.ncd1_temperature_1",
+  "description": "NCD1_Temperature_1",
+  "securityDefinitions": {
+    "ha_sc": {
+      "scheme": "bearer"
+    }
+  },
+  "security": "ha_sc",
+  "created": "2022-04-22T16:55:09.476Z",
+  "properties": {
+    "states": {
+      "type": "object",
+      "properties": {
+        "entity_id": {
+          "type": "string"
+        },
+        "state": {
+          "type": "number",
+          "unit": "qudt:degree_centigrade"
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "unit_of_measurement": {
+              "type": "string",
+              "const": "°C"
+            },
+            "friendly_name": {
+              "type": "string"
+            }
+          }
+        },
+        "last_changed": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "context": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "parent_id": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "user_id": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "form": {
+        "href": "states/sensor.ncd1_temperature_1"
+      }
+    }
+  }
+}

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.ncd1_temperature_1.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.ncd1_temperature_1.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:532f089d-8fff-406d-9809-37caa1571c37",
+  "id": "urn:uuid:0dd8fbfa-20ae-421c-ab79-66aeefb02855",
   "title": "sensor.ncd1_temperature_1",
   "description": "NCD1_Temperature_1",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T16:55:09.476Z",
+  "created": "2022-04-22T22:03:01.495Z",
   "properties": {
     "states": {
       "type": "object",
@@ -74,9 +74,11 @@
           }
         }
       },
-      "form": {
-        "href": "states/sensor.ncd1_temperature_1"
-      }
+      "forms": [
+        {
+          "href": "states/sensor.ncd1_temperature_1"
+        }
+      ]
     }
   }
 }

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.ncd1_temperature_1.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.ncd1_temperature_1.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:6c4449d8-8d0e-4df3-b1cd-45ce695bcac9",
+  "id": "urn:uuid:51639856-2a5a-4a5e-85f9-efce0f0461a1",
   "title": "sensor.ncd1_temperature_1",
   "description": "NCD1_Temperature_1",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:13:20.811Z",
+  "created": "2022-04-22T22:29:47.944Z",
   "properties": {
     "states": {
       "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.ncd1_temperature_1.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.ncd1_temperature_1.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:968481ca-2616-46a5-a2e0-a314f8f49e90",
+  "id": "urn:uuid:1ec8bbcf-6c47-48c6-9135-b3d0c356bc8c",
   "title": "sensor.ncd1_temperature_1",
   "description": "NCD1_Temperature_1",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:40:09.071Z",
+  "created": "2022-04-22T22:47:11.362Z",
   "properties": {
     "states": {
       "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.ncd1_temperature_1.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.ncd1_temperature_1.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:51639856-2a5a-4a5e-85f9-efce0f0461a1",
+  "id": "urn:uuid:968481ca-2616-46a5-a2e0-a314f8f49e90",
   "title": "sensor.ncd1_temperature_1",
   "description": "NCD1_Temperature_1",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:29:47.944Z",
+  "created": "2022-04-22T22:40:09.071Z",
   "properties": {
     "states": {
       "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.shelly_dw2_1_state.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.shelly_dw2_1_state.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:d4b9fb67-dc40-4589-a029-f533b648e862",
+  "id": "urn:uuid:910eb90b-093e-44f3-b061-842fdfacc134",
   "title": "sensor.shelly_dw2_1_state",
   "description": "Shelly_DW2_1_State",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:47:11.367Z",
+  "created": "2022-04-26T00:52:01.611Z",
   "properties": {
     "states": {
       "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.shelly_dw2_1_state.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.shelly_dw2_1_state.td.jsonld
@@ -1,0 +1,76 @@
+{
+  "@context": [
+    "https://www.w3.org/2022/wot/td/v1.1"
+  ],
+  "base": "http://192.168.1.75:8123/api/",
+  "@type": "Thing",
+  "id": "urn:uuid:230f8640-c4f9-46d7-9438-3b7492883166",
+  "title": "sensor.shelly_dw2_1_state",
+  "description": "Shelly_DW2_1_State",
+  "securityDefinitions": {
+    "ha_sc": {
+      "scheme": "bearer"
+    }
+  },
+  "security": "ha_sc",
+  "created": "2022-04-22T16:55:09.479Z",
+  "properties": {
+    "states": {
+      "type": "object",
+      "properties": {
+        "entity_id": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "open",
+            "close"
+          ]
+        },
+        "attributes": {
+          "friendly_name": {
+            "type": "string"
+          }
+        },
+        "last_changed": {
+          "type": "xsd:datetime"
+        },
+        "last_updated": {
+          "type": "xsd:datetime"
+        },
+        "context": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "parent_id": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "user_id": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "form": {
+        "href": "states/sensor.shelly_dw2_1_state"
+      }
+    }
+  }
+}

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.shelly_dw2_1_state.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.shelly_dw2_1_state.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:5712a674-75e0-43ab-afe8-696cd9fffb4a",
+  "id": "urn:uuid:4b5d88a7-7218-40e5-b3f2-65fec021431a",
   "title": "sensor.shelly_dw2_1_state",
   "description": "Shelly_DW2_1_State",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:03:01.499Z",
+  "created": "2022-04-22T22:13:20.815Z",
   "properties": {
     "states": {
       "type": "object",
@@ -34,10 +34,12 @@
           }
         },
         "last_changed": {
-          "type": "xsd:datetime"
+          "type": "string",
+          "format": "date-time"
         },
         "last_updated": {
-          "type": "xsd:datetime"
+          "type": "string",
+          "format": "date-time"
         },
         "context": {
           "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.shelly_dw2_1_state.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.shelly_dw2_1_state.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:639bdf36-7e48-4f6b-9fac-3515fc914b2a",
+  "id": "urn:uuid:798659bd-3453-40fb-bff2-0bf36da664b8",
   "title": "sensor.shelly_dw2_1_state",
   "description": "Shelly_DW2_1_State",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:29:47.948Z",
+  "created": "2022-04-22T22:40:09.075Z",
   "properties": {
     "states": {
       "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.shelly_dw2_1_state.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.shelly_dw2_1_state.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:798659bd-3453-40fb-bff2-0bf36da664b8",
+  "id": "urn:uuid:d4b9fb67-dc40-4589-a029-f533b648e862",
   "title": "sensor.shelly_dw2_1_state",
   "description": "Shelly_DW2_1_State",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:40:09.075Z",
+  "created": "2022-04-22T22:47:11.367Z",
   "properties": {
     "states": {
       "type": "object",

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.shelly_dw2_1_state.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.shelly_dw2_1_state.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:230f8640-c4f9-46d7-9438-3b7492883166",
+  "id": "urn:uuid:5712a674-75e0-43ab-afe8-696cd9fffb4a",
   "title": "sensor.shelly_dw2_1_state",
   "description": "Shelly_DW2_1_State",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T16:55:09.479Z",
+  "created": "2022-04-22T22:03:01.499Z",
   "properties": {
     "states": {
       "type": "object",
@@ -68,9 +68,11 @@
           }
         }
       },
-      "form": {
-        "href": "states/sensor.shelly_dw2_1_state"
-      }
+      "forms": [
+        {
+          "href": "states/sensor.shelly_dw2_1_state"
+        }
+      ]
     }
   }
 }

--- a/events/2022.03.Online/TD/intel-wot-ha/sensor.shelly_dw2_1_state.td.jsonld
+++ b/events/2022.03.Online/TD/intel-wot-ha/sensor.shelly_dw2_1_state.td.jsonld
@@ -4,7 +4,7 @@
   ],
   "base": "http://192.168.1.75:8123/api/",
   "@type": "Thing",
-  "id": "urn:uuid:4b5d88a7-7218-40e5-b3f2-65fec021431a",
+  "id": "urn:uuid:639bdf36-7e48-4f6b-9fac-3515fc914b2a",
   "title": "sensor.shelly_dw2_1_state",
   "description": "Shelly_DW2_1_State",
   "securityDefinitions": {
@@ -13,7 +13,7 @@
     }
   },
   "security": "ha_sc",
-  "created": "2022-04-22T22:13:20.815Z",
+  "created": "2022-04-22T22:29:47.948Z",
   "properties": {
     "states": {
       "type": "object",


### PR DESCRIPTION
I have been working on a project to extract information from the Home Assistant RESTful API and express access to various Home Assistant "entities" as WoT TDs.  This PR includes six example TDs generated this way.

This has not been completely successful because of the way the Home Assistant API mixes data and metadata.  The API does not really include ALL the metadata needed to generate a TD, some of it is implicit in the Home Assistant documentation, some is not exposed through the API, some is inconsistently exposed (such as the device categories, sometimes an entity is only defined as a "sensor", and "binary_sensors" might use different values for on-off depending on their device category, etc. etc.).  Also, some things like events need JSON RPC and Web Sockets which WoT does not do yet.

In the long run a Home Assistant "add-on" is probably needed to do this properly...

Good news is HA uses bearer tokens so this adds a test for that security mechanism.  Bad news is HA requires bearer tokens even if you are using plain HTTP (which is pointless), and it only has a primitive mechanism to limit scopes (so if I open up my HA to a tester, I have to open ALL devices on that instance, not just specific ones; there are "groups" under development in HA but they aren't enforced yet).

See the README.md for more details.