### PR TITLE
Create 2022.06.Online

### DIFF
--- a/events/2022.06.Online
+++ b/events/2022.06.Online
@@ -1,4 +1,29 @@
 # Testfest
-4-8 June 2022
+To focus *completely* on testing and completing the Implementation Reports for *all* deliverables.
+Note that the Profile spec will still be "mutable" but we will still focus on testing assertions
+in an actual draft as opposed to proposing completely new items.
+We also need to focus on gaps where features are at risk.
 
-* Details to follow
+## Logistics
+* Date: 6-10 June 2022
+* Time Proposals: [doodle](link)
+   - 7am Eastern Daily
+   - 8am Eastern Daily except Wed to avoid Main call, 9am Eastern Wed
+   - 9am Eastern Daily
+   - 10am Eastern Daily
+* WebEx: TBD (Cisco WebEx?)
+* Slack: TBD
+* Hangouts: TBD
+* Other
+   - Details to follow
+
+## TO DO
+- Copy 03.Online event for initial state (do May 25 in testing call)
+- Set up VLAN
+- (Re)organize directory structure
+- Organize instructions in appropriate README.md files and index
+- Capture input data
+- Generate results
+- Generating manual.csv files
+- Update Implementation Report templates
+- Completing Implementation Descriptions and draft Testimonials

--- a/events/2022.06.Online
+++ b/events/2022.06.Online
@@ -1,0 +1,4 @@
+# Testfest
+4-8 June 2022
+
+* Details to follow


### PR DESCRIPTION
Draft for organizing next testfest.  I will fill in some blanks (e.g. directory structure) and we can discuss how to proceed from there.  Propose starting by copying content from 2022.03.Online directory on 1 June.