### PR TITLE
new node-wot samples to improve test repor 

### DIFF
--- a/events/2022.06.Online/TD/node-wot/TDs/siemens-counter.td.jsonld
+++ b/events/2022.06.Online/TD/node-wot/TDs/siemens-counter.td.jsonld
@@ -199,6 +199,11 @@
 		"de": "Zähler Beispiel Ding",
 		"it": "Contatore Esempio"
 	},
+	"links": [{
+		"href": "https://www.thingweb.io/img/favicon/favicon.png",
+		"sizes": "16x14",
+		"rel": "icon"
+	}],
 	"support": "git://github.com/eclipse/thingweb.node-wot.git",
 	"uriVariables": {
 		"step": {

--- a/events/2022.06.Online/TD/node-wot/TDs/siemens-dataSchemas.js
+++ b/events/2022.06.Online/TD/node-wot/TDs/siemens-dataSchemas.js
@@ -6,42 +6,45 @@ let restrictedString;
 WoT.produce({
     title: "dataSchemas",
     description: "dataSchemas example Thing",
-    support: "git://github.com/eclipse/thingweb.node-wot.git",
-    "@context": [
-        "https://www.w3.org/2019/wot/td/v1",
-        "https://www.w3.org/2022/wot/td/v1.1"
-    ],
+    support: "https://github.com/eclipse/thingweb.node-wot/",
+    "@context": ["https://www.w3.org/2019/wot/td/v1", "https://www.w3.org/2022/wot/td/v1.1"],
     properties: {
         multipleInteger5: {
             type: "integer",
-			multipleOf: 5,
+            multipleOf: 5,
         },
         multipleNumber2_5: {
             type: "number",
-			multipleOf: 2.5,
+            multipleOf: 2.5,
         },
         restrictedInteger: {
             type: "integer",
-			exclusiveMinimum: 0,
-			exclusiveMaximum: 5,
+            exclusiveMinimum: 0,
+            exclusiveMaximum: 5,
         },
         restrictedNumber: {
             type: "number",
-			exclusiveMinimum: 100.0,
-			exclusiveMaximum: 1000.0,
+            exclusiveMinimum: 100.0,
+            exclusiveMaximum: 1000.0,
         },
         restrictedString: {
-			description: "String for ISO language code, 2 alphabetical characters, a dash, and 2 more alphabetical characters, like en-GB",
+            description:
+                "String for ISO language code, 2 alphabetical characters, a dash, and 2 more alphabetical characters, like en-GB",
             type: "string",
-			minLength: 2,
-			maxLength: 5,
-			pattern : "^[a-z]{2}-[A-Z]{2}",
+            minLength: 2,
+            maxLength: 5,
+            pattern: "^[a-z]{2}-[A-Z]{2}",
+        },
+        defaultString: {
+            description: "String with default value",
+            type: "string",
+            default: "Initial",
         },
         imageAsBase64: {
             description: "Red dot PNG image in base64 string",
-			type: "string",
-			contentMediaType: "image/png",
-			contentEncoding: "base64",
+            type: "string",
+            contentMediaType: "image/png",
+            contentEncoding: "base64",
             observable: false,
             readOnly: true,
         },
@@ -50,57 +53,66 @@ WoT.produce({
     .then((thing) => {
         console.log("Produced " + thing.getThingDescription().title);
         // init property values
-		multipleInteger5 = 5;
-		multipleNumber2_5 = 2.5;
+        multipleInteger5 = 5;
+        multipleNumber2_5 = 2.5;
         restrictedInteger = 1;
-		restrictedNumber = 100.1;
-		restrictedString = "en-GB"
+        restrictedNumber = 100.1;
+        restrictedString = "en-GB";
+        defaultString = "Initial";
         // set property handlers (using async-await)
-		// multipleInteger5
-		thing.setPropertyWriteHandler("multipleInteger5", async (val) => {
-			// note-wot checks constraints
-			// * td-data-schema_multipleOf-IntegerSchema	5
+        // multipleInteger5
+        thing.setPropertyWriteHandler("multipleInteger5", async (val) => {
+            // note-wot checks constraints
+            // * td-data-schema_multipleOf-IntegerSchema	5
             multipleInteger5 = await val.value();
         });
         thing.setPropertyReadHandler("multipleInteger5", async () => multipleInteger5);
-		// multipleNumber2_5
-		thing.setPropertyWriteHandler("multipleNumber2_5", async (val) => {
-			// note-wot checks constraints
-			// * td-data-schema_multipleOf-NumberSchema	2.5
+        // multipleNumber2_5
+        thing.setPropertyWriteHandler("multipleNumber2_5", async (val) => {
+            // note-wot checks constraints
+            // * td-data-schema_multipleOf-NumberSchema	2.5
             multipleNumber2_5 = await val.value();
         });
         thing.setPropertyReadHandler("multipleNumber2_5", async () => multipleNumber2_5);
-		// restrictedInteger
-		thing.setPropertyWriteHandler("restrictedInteger", async (val) => {
-			// note-wot checks constraints
-			// * td-data-schema_exclusiveMinimum-IntegerSchema	0
-			// * td-data-schema_exclusiveMaximum-IntegerSchema	5
+        // restrictedInteger
+        thing.setPropertyWriteHandler("restrictedInteger", async (val) => {
+            // note-wot checks constraints
+            // * td-data-schema_exclusiveMinimum-IntegerSchema	0
+            // * td-data-schema_exclusiveMaximum-IntegerSchema	5
             restrictedInteger = await val.value();
         });
         thing.setPropertyReadHandler("restrictedInteger", async () => restrictedInteger);
-		// restrictedNumber
-		thing.setPropertyWriteHandler("restrictedNumber", async (val) => {
-			// note-wot checks constraints
-			// * td-data-schema_exclusiveMinimum-NumberSchema	100.0
-			// * td-data-schema_exclusiveMaximum-NumberSchema	1000.0
+        // restrictedNumber
+        thing.setPropertyWriteHandler("restrictedNumber", async (val) => {
+            // note-wot checks constraints
+            // * td-data-schema_exclusiveMinimum-NumberSchema	100.0
+            // * td-data-schema_exclusiveMaximum-NumberSchema	1000.0
             restrictedNumber = await val.value();
         });
-		thing.setPropertyReadHandler("restrictedNumber", async () => restrictedNumber);
-		// restrictedString
-		thing.setPropertyWriteHandler("restrictedString", async (val) => {
-			// note-wot checks constraints
-			// * td-data-schema_minLength	2
-			// * td-data-schema_maxLength	5
-			// * td-data-schema_pattern		^[a-z]{2}-[A-Z]{2}
+        thing.setPropertyReadHandler("restrictedNumber", async () => restrictedNumber);
+        // restrictedString
+        thing.setPropertyWriteHandler("restrictedString", async (val) => {
+            // note-wot checks constraints
+            // * td-data-schema_minLength	2
+            // * td-data-schema_maxLength	5
+            // * td-data-schema_pattern		^[a-z]{2}-[A-Z]{2}
             restrictedString = await val.value();
         });
-		thing.setPropertyReadHandler("restrictedString", async () => restrictedString);
-		// supports the following assertions
-		// * td-data-schema_contentEncoding
-		// * td-data-schema_contentMediaType
+        thing.setPropertyReadHandler("restrictedString", async () => restrictedString);
+        // defaultString
+        thing.setPropertyWriteHandler("defaultString", async (val) => {
+            // note-wot checks constraints
+            // * td-vocab-default--DataSchema
+            defaultString = await val.value();
+        });
+        thing.setPropertyReadHandler("defaultString", async () => defaultString);
+        // supports the following assertions
+        // * td-data-schema_contentEncoding
+        // * td-data-schema_contentMediaType
         thing.setPropertyReadHandler(
             "imageAsBase64",
-            async () =>  "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=="
+            async () =>
+                "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=="
         );
         // expose the thing
         thing.expose().then(() => {

--- a/events/2022.06.Online/TD/node-wot/TDs/siemens-dataSchemas.jsonld
+++ b/events/2022.06.Online/TD/node-wot/TDs/siemens-dataSchemas.jsonld
@@ -3,6 +3,12 @@
 		"@language": "en"
 	}],
 	"@type": "Thing",
+	"title": "dataSchemas",
+	"securityDefinitions": {
+		"nosec_sc": {
+			"scheme": "nosec"
+		}
+	},
 	"security": ["nosec_sc"],
 	"properties": {
 		"multipleInteger5": {
@@ -130,6 +136,31 @@
 			"writeOnly": false,
 			"observable": false
 		},
+		"defaultString": {
+			"description": "String with default value",
+			"type": "string",
+			"default": "Initial",
+			"forms": [{
+				"href": "http://192.168.178.24:8080/dataschemas/properties/defaultString",
+				"contentType": "application/json",
+				"op": ["readproperty", "writeproperty"]
+			}, {
+				"href": "http://169.254.138.34:8080/dataschemas/properties/defaultString",
+				"contentType": "application/json",
+				"op": ["readproperty", "writeproperty"]
+			}, {
+				"href": "coap://192.168.178.24:5683/dataschemas/properties/defaultString",
+				"contentType": "application/json",
+				"op": ["readproperty", "writeproperty"]
+			}, {
+				"href": "coap://169.254.138.34:5683/dataschemas/properties/defaultString",
+				"contentType": "application/json",
+				"op": ["readproperty", "writeproperty"]
+			}],
+			"readOnly": false,
+			"writeOnly": false,
+			"observable": false
+		},
 		"imageAsBase64": {
 			"description": "Red dot PNG image in base64 string",
 			"type": "string",
@@ -159,10 +190,9 @@
 			"writeOnly": false
 		}
 	},
-	"title": "dataSchemas",
+	"id": "urn:uuid:40134abe-acdc-4c2f-b5a6-b3b6b0d96f02",
 	"description": "dataSchemas example Thing",
-	"support": "git://github.com/eclipse/thingweb.node-wot.git",
-	"id": "urn:uuid:e47b6ce8-bbe9-497f-818f-02b9f2935d44",
+	"support": "https://github.com/eclipse/thingweb.node-wot/",
 	"forms": [{
 		"href": "http://192.168.178.24:8080/dataschemas/properties",
 		"contentType": "application/json",
@@ -171,10 +201,5 @@
 		"href": "http://169.254.138.34:8080/dataschemas/properties",
 		"contentType": "application/json",
 		"op": ["readallproperties", "readmultipleproperties", "writeallproperties", "writemultipleproperties"]
-	}],
-	"securityDefinitions": {
-		"nosec_sc": {
-			"scheme": "nosec"
-		}
-	}
+	}]
 }


### PR DESCRIPTION
As discussed when dealing with https://w3c.github.io/wot-thing-description/testing/report11.html I added 2 more examples for
* td-vocab-default--DataSchema
* add td-vocab-sizes--Link