### PR TITLE
Added TM examples showing `tm:optional` usage in scope of Ditto/TMs

### DIFF
--- a/data/input_2022/TD/Ditto/TMs/ditto_tm_optional_altitude-sensor-1.0.0.tm.jsonld
+++ b/data/input_2022/TD/Ditto/TMs/ditto_tm_optional_altitude-sensor-1.0.0.tm.jsonld
@@ -1,0 +1,47 @@
+{
+  "@context": [
+    "https://www.w3.org/2022/wot/td/v1.1",
+    {
+      "om2": "http://www.ontology-of-units-of-measure.org/resource/om-2/"
+    }
+  ],
+  "@type": "tm:ThingModel",
+  "title": "Altitude Sensor",
+  "version": {
+    "model": "1.0.0"
+  },
+  "links": [
+    {
+      "rel": "tm:extends",
+      "href": "https://eclipse.github.io/ditto-examples/wot/models/sensors/min-max-aware-sensor-1.0.0.tm.jsonld",
+      "type": "application/tm+json"
+    }
+  ],
+  "tm:optional": [
+    "/properties/minMeasuredAltitude",
+    "/properties/maxMeasuredAltitude"
+  ],
+  "properties": {
+    "currentAltitude": {
+      "@type": "om2:Height",
+      "title": "Current altitude",
+      "description": "The last or current measured altitude above sea level in 'm'.",
+      "type": "number",
+      "unit": "om2:metre"
+    },
+    "minMeasuredAltitude": {
+      "@type": "om2:Height",
+      "title": "Minimum measured altitude",
+      "description": "The minimum measured altitude above sea level since power ON or reset in 'm'.",
+      "type": "number",
+      "unit": "om2:metre"
+    },
+    "maxMeasuredAltitude": {
+      "@type": "om2:Height",
+      "title": "Maximum measured altitude",
+      "description": "The maximum measured altitude above sea level since power ON or reset in 'm'.",
+      "type": "number",
+      "unit": "om2:metre"
+    }
+  }
+}

--- a/data/input_2022/TD/Ditto/TMs/ditto_tm_optional_colored-lamp-1.0.0.tm.jsonld
+++ b/data/input_2022/TD/Ditto/TMs/ditto_tm_optional_colored-lamp-1.0.0.tm.jsonld
@@ -1,0 +1,50 @@
+{
+  "@context": [
+    "https://www.w3.org/2022/wot/td/v1.1"
+  ],
+  "@type": "tm:ThingModel",
+  "title": "Colored Lamp",
+  "version": {
+    "model": "1.0.0"
+  },
+  "links": [
+    {
+      "rel": "tm:extends",
+      "href": "https://eclipse.github.io/ditto-examples/wot/models/switchable-1.0.0.tm.jsonld",
+      "type": "application/tm+json"
+    }
+  ],
+  "tm:optional": [],
+  "properties": {
+    "color": {
+      "title": "Color",
+      "description": "The current color.",
+      "type": "object",
+      "properties": {
+        "r": {
+          "title": "Red",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "g": {
+          "title": "Green",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "b": {
+          "title": "Blue",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        }
+      },
+      "required": [
+        "r",
+        "g",
+        "b"
+      ]
+    }
+  }
+}

--- a/data/input_2022/TD/Ditto/TMs/ditto_tm_optional_min-max-aware-sensor-1.0.0.tm.jsonld
+++ b/data/input_2022/TD/Ditto/TMs/ditto_tm_optional_min-max-aware-sensor-1.0.0.tm.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": [
+    "https://www.w3.org/2022/wot/td/v1.1"
+  ],
+  "@type": "tm:ThingModel",
+  "title": "Min/max Aware Sensor",
+  "version": {
+    "model": "1.0.0"
+  },
+  "tm:optional": [
+    "/actions/resetMinMaxMeasurements"
+  ],
+  "actions": {
+    "resetMinMaxMeasurements": {
+      "title": "Reset min/max measurement",
+      "description": "Resets the minimum and maximum sensor measurement to the current sensor value."
+    }
+  }
+}

--- a/data/input_2022/TD/Ditto/TMs/ditto_tm_optional_switchable-1.0.0.tm.jsonld
+++ b/data/input_2022/TD/Ditto/TMs/ditto_tm_optional_switchable-1.0.0.tm.jsonld
@@ -1,0 +1,43 @@
+{
+  "@context": [
+    "https://www.w3.org/2022/wot/td/v1.1",
+    {
+      "time": "http://www.w3.org/2006/time#"
+    }
+  ],
+  "@type": "tm:ThingModel",
+  "title": "Switchable",
+  "version": {
+    "model": "1.0.0"
+  },
+  "tm:optional": [
+    "/actions/switch-on-for-duration"
+  ],
+  "properties": {
+    "on": {
+      "title": "On",
+      "description": "Whether the switch is on or off.",
+      "type": "boolean"
+    }
+  },
+  "actions": {
+    "toggle": {
+      "title": "Toggle",
+      "description": "Toggles/inverts the current 'on' state.",
+      "output": {
+        "title": "New 'on' state",
+        "type": "boolean"
+      }
+    },
+    "switch-on-for-duration": {
+      "title": "Switch on for duration",
+      "description": "Switches the switchable on for a given duration, then switches back to the previous state.",
+      "input": {
+        "@type": "time:Duration",
+        "title": "Duration in seconds",
+        "type": "integer",
+        "unit": "time:seconds"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added example TMs to show potential usage of `tm:optional` as suggested by @egekorkan in https://github.com/w3c/wot-thing-description/issues/1594#issuecomment-1190624411