### PR TITLE
Add July discovery files

### DIFF
--- a/events/2022.07.Online/Discovery/Inputs/README.md
+++ b/events/2022.07.Online/Discovery/Inputs/README.md
@@ -1,0 +1,8 @@
+# WoT Discovery Test Input
+This directory contains raw test results for implementations.
+
+Place the results in subdirectories by implementation.
+
+Manual and automatic testing results can be maintained as separate csv files:
+- manual.csv
+- auto.csv

--- a/events/2022.07.Online/Discovery/README.md
+++ b/events/2022.07.Online/Discovery/README.md
@@ -1,0 +1,23 @@
+# WoT March 2022 Plugfest/Testfest
+
+## Prework
+- [ ] Update Implementation Report draft
+- [ ] Update template.csv
+- [ ] Update manual.csv 
+
+## Testfest
+- [ ] Capture test results (put in [Results](Results/README.md))
+- [ ] Describe each implementation (put in [Architecture/ImplDesc](../Architecture/ImplDescs))
+- [ ] Capture name and activity status of each implementation in [active.csv](active.csv)
+- [ ] Create a CSV file, manual.csv, listing the assertions that can were asserted manually.
+
+The [template.csv](template.csv) file contains a list of all the current assertions in 
+the WoT Discovery specification.  
+* The "null" entries should be changed to "pass" or "fail" for each
+  implementation and a modified copy, named after the implementation, placed in the 
+  Results directory.  
+* The implementation report generator will then read these and tabulate
+  the number of each for all implementations.  
+* It is ok to include manual as well as automatically tested assertions in the same file.  
+* Later on (see above) we can use a table of the assertions that are manual to structure the 
+  implementation report.

--- a/events/2022.07.Online/Discovery/README.md
+++ b/events/2022.07.Online/Discovery/README.md
@@ -6,18 +6,18 @@
 - [ ] Update manual.csv 
 
 ## Testfest
-- [ ] Capture test results (put in [Results](Results/README.md))
+- [ ] Capture test results (maintained in [Inputs](Inputs) and [Results](Results))
 - [ ] Describe each implementation (put in [Architecture/ImplDesc](../Architecture/ImplDescs))
 - [ ] Capture name and activity status of each implementation in [active.csv](active.csv)
-- [ ] Create a CSV file, manual.csv, listing the assertions that can were asserted manually.
 
-The [template.csv](template.csv) file contains a list of all the current assertions in 
-the WoT Discovery specification.  
+
+The [template.csv](https://github.com/w3c/wot-discovery/blob/main/testing/template.csv) file contains a list of all the current assertions in 
+the WoT Discovery specification. The [manual.csv](https://github.com/w3c/wot-discovery/blob/main/testing/manual.csv) contains a list of assertions that aren't covered by farshidtz's [directory testing tool](https://github.com/farshidtz/wot-discovery-testing/tree/main/directory).
 * The "null" entries should be changed to "pass" or "fail" for each
   implementation and a modified copy, named after the implementation, placed in the 
   Results directory.  
 * The implementation report generator will then read these and tabulate
   the number of each for all implementations.  
-* It is ok to include manual as well as automatically tested assertions in the same file.  
+* It is ok to include manual as well as automatically tested assertions in the same file.
 * Later on (see above) we can use a table of the assertions that are manual to structure the 
   implementation report.

--- a/events/2022.07.Online/Discovery/Results/README.md
+++ b/events/2022.07.Online/Discovery/Results/README.md
@@ -1,3 +1,6 @@
 # WoT Discovery Test Results
-- Put raw results of tests in subdirectories by implemention
-- Put CSV files for each implementation at the top level (will be used for implementation report generation)
+Test results that are used for implementation report generation.
+
+Put CSV files for each implementation at the top level.
+
+For raw test inputs, refer to the [Inputs directory](../Inputs).

--- a/events/2022.07.Online/Discovery/Results/README.md
+++ b/events/2022.07.Online/Discovery/Results/README.md
@@ -1,0 +1,3 @@
+# WoT Discovery Test Results
+- Put raw results of tests in subdirectories by implemention
+- Put CSV files for each implementation at the top level (will be used for implementation report generation)

--- a/events/2022.07.Online/Discovery/active.csv
+++ b/events/2022.07.Online/Discovery/active.csv
@@ -1,0 +1,5 @@
+"Org","Name","on VLAN","on Internet","Link","Comment","Thing Name (File basename)","Implementation ID", "Remarks"
+"Fraunhofer","LinkSmart Thing Directory","no","no",https://github.com/linksmart/thing-directory,"todo",linksmart,fraunhofer,
+"Siemens","LogilabTDD","no","yes",https://siemens-wot.demo.logilab.fr/,"",logilabtdd,siemens-logilab,
+"Hitachi","Node-RED Discoverer","no","no",none,"",nrwotdisc,hitachi-nrwotdisc,
+"TinyIoT","Thing Directory","no","no",https://github.com/TinyIoT/thing-directory,,tinyiot,tinyiot-tdd,

--- a/events/2022.07.Online/Discovery/active.csv
+++ b/events/2022.07.Online/Discovery/active.csv
@@ -1,5 +1,4 @@
 "Org","Name","on VLAN","on Internet","Link","Comment","Thing Name (File basename)","Implementation ID", "Remarks"
-"Fraunhofer","LinkSmart Thing Directory","no","no",https://github.com/linksmart/thing-directory,"todo",linksmart,fraunhofer,
 "Siemens","LogilabTDD","no","yes",https://siemens-wot.demo.logilab.fr/,"",logilabtdd,siemens-logilab,
 "Hitachi","Node-RED Discoverer","no","no",none,"",nrwotdisc,hitachi-nrwotdisc,
 "TinyIoT","Thing Directory","no","no",https://github.com/TinyIoT/thing-directory,,tinyiot,tinyiot-tdd,


### PR DESCRIPTION
As requested in the discovery call, I'm copying the files from June's testfest. 

The READMEs were out of date with respect to the existence of the Inputs directory. Here is the diff: https://github.com/w3c/wot-testing/pull/369/commits/9c5444031a1f8a1f1f0c4af45e26abc27e53b1a6

I've added hyperlinks to sources of template.csv and manual.csv files.