### PR TITLE
add optional "name" term to basic security

### DIFF
--- a/data/input_2022/TD/node-wot/TDs/siemens-my-thing-profile.jsonld
+++ b/data/input_2022/TD/node-wot/TDs/siemens-my-thing-profile.jsonld
@@ -3,7 +3,7 @@
 	"profile": "https://www.siemens.com/2022/wot/profile/dev/v1",
     "title": "MyThing",
     "securityDefinitions": {
-        "basic_sc": {"scheme": "basic", "in": "header"}
+        "basic_sc": {"scheme": "basic", "in": "header", "name": "Authorization"}
     },
     "security": "basic_sc",
     "properties": {


### PR DESCRIPTION
`name` in [BasicSecurityScheme](https://w3c.github.io/wot-thing-description/#basicsecurityscheme) is still at risk. Hence I have added a simple example of it in an existing TD...