### PR TITLE
Update playground.html

### DIFF
--- a/data/input_2022/Architecture/Impls/playground.html
+++ b/data/input_2022/Architecture/Impls/playground.html
@@ -3,8 +3,8 @@
   <p>
     The Thing Description Playground implementation is a set of tools that
     allows one to validate TDs, as well to transform them into different
-    representations such as OpenAPI and AsyncAPI. It also allows to detect
-    implemented assertions of the TD spec by looking at a TD, which is how the
+    representations such as OpenAPI and AsyncAPI or to manipulate TDs to add or remove default terms and values. 
+    It also allows to detect implemented assertions of the TD spec by looking at a TD, which is how the
     implementation report for the TD is generated.
   </p>
   <p>
@@ -15,5 +15,5 @@
     <b>Public Repository:</b> https://github.com/thingweb/thingweb-playground
     <b>Website:</b> http://plugfest.thingweb.io/playground/
   </p>
-  <p><b>Contributing Member Organizations:</b> Siemens AG</p>
+  <p><b>Contributing Member Organizations:</b>Siemens AG</p>
 </div>


### PR DESCRIPTION
As discussed in the testing call today, the addition and removal of defaults was missing from the implementation description of playground. I have added that here. 

Also as agreed in the call and since this implementation is maintained by Siemens, I will merge it now