### PR TITLE
Improve security assertions for saywot

### DIFF
--- a/data/input_2022/Architecture/Results/saywot.csv
+++ b/data/input_2022/Architecture/Results/saywot.csv
@@ -39,8 +39,8 @@
 "arch-security-consideration-avoid-direct","not-impl",
 "arch-security-consideration-communication-binding","not-impl",
 "arch-security-consideration-communication-platform","not-impl",
-"arch-security-consideration-dtls-1-2","null", "need feedback from implementers" 
-"arch-security-consideration-dtls-1-3","null", "need feedback from implementers" 
+"arch-security-consideration-dtls-1-2","not-impl",
+"arch-security-consideration-dtls-1-3","not-impl",
 "arch-security-consideration-hal-refuse-unsafe","not-impl",
 "arch-security-consideration-isolation-sensitive","not-impl",
 "arch-security-consideration-isolation-tenants","not-impl",
@@ -54,13 +54,13 @@
 "arch-security-consideration-secure-update","not-impl",
 "arch-security-consideration-segmented-network","not-impl",
 "arch-security-consideration-separate-security-data","not-impl",
-"arch-security-consideration-tls-1-2","null", "need feedback from implementers" 
-"arch-security-consideration-tls-1-3","null", "need feedback from implementers" 
-"arch-security-consideration-tls-mandatory-pub","null", "need feedback from implementers" 
+"arch-security-consideration-tls-1-2","pass",
+"arch-security-consideration-tls-1-3","pass",
+"arch-security-consideration-tls-mandatory-pub","not-impl",
 "arch-security-consideration-tls-optional-on-lan","pass", 
 "arch-security-consideration-tls-recommended-priv","not-impl",
 "arch-security-consideration-use-hal","not-impl",
-"arch-security-consideration-use-psk","null", "need feedback from implementers"
+"arch-security-consideration-use-psk","not-impl",
 "arch-td-linking","pass",
 "arch-td-mandatory","pass",
 "arch-td-metadata","pass",


### PR DESCRIPTION
After talking with @fexpal , here is what is done about dtls/tls in saywot. Basically, DTLS is not used since there is no coaps northbound but tls 1.3 is used