### PR TITLE
Mark Size2 Discovery feature as "pass" for RIOT implementation

### DIFF
--- a/data/input_2022/Discovery/riot-wot/manual.csv
+++ b/data/input_2022/Discovery/riot-wot/manual.csv
@@ -16,7 +16,7 @@
 "exploration-server-coap-alternate-content","pass",
 "exploration-server-coap-method","pass",
 "exploration-server-coap-resp","pass",
-"exploration-server-coap-size2","fail",
+"exploration-server-coap-size2","pass",
 "sec-tdd-intro-no-observe","pass",
 "sec-tdd-intro-limit-response-size","null",
 "introduction-core-rd","pass",


### PR DESCRIPTION
The RIOT implementation now supports the CoAP Size2 feature from the Discovery specification. This PR updates the `manual.csv` file accordingly.

I noticed, by the way, that the formulation of the assertion could be a bit more precise and aligned with [section 4 of RFC 7959](https://www.rfc-editor.org/rfc/rfc7959#section-4). For instance, the RFC requires that the option value *must* be set to 0 in requests, while our formulation is a bit ambiguous and could be interpreted as if a server should react to *any* request containing the option by including a size estimate in its next response. IMHO this would only be an editorial change, though, and keeping it as is would also be fine since the RFC already clarifies the behavior.