### PR TITLE
Fix the title of Philips Hue Implementation

### DIFF
--- a/data/input_2022/Architecture/Impls/philips-hue.html
+++ b/data/input_2022/Architecture/Impls/philips-hue.html
@@ -1,5 +1,5 @@
 <div class="impl" id="impl-philips-hue">
-  <h4 id="impl-philips-hue">Thing Description Playground: Tool</h4>
+  <h4 id="impl-philips-hue">Philips Hue Integration</h4>
   <p>
     This implementation leverages the already developed Philips Hue devices. The TDs for them are written by hand and show the use of WoT for brownfield
     devices. Philips Hue uses API Key in the URI, which is one of the features of the TD 1.1.


### PR DESCRIPTION
It seems that I did a copy-paste mistake, this PR fixes a title of an implementation I have contributed.