### PR TITLE
Add text direction guess pass to playground

### DIFF
--- a/data/input_2022/TD/Playground/Playground.csv
+++ b/data/input_2022/TD/Playground/Playground.csv
@@ -70,7 +70,7 @@
 "td-producer-mixed-direction","null", ,"TD producers SHOULD attempt to provide mixed direction strings in a way that can be displayed successfully by a naive user agent."
 "td-security-extension","null", ,"Additional security schemes MUST be Subclasses of the Class SecurityScheme."
 "td-text-direction-first-strong","pass", ,"When metadata such as @direction is not present, TD Consumers SHOULD use [=first-strong detection=] as a fallback."
-"td-text-direction-language-tag","not-impl", ,"For the MultiLanguage Map, TD Consumers MAY infer the [=base direction=] from the language tag of the individual strings."
+"td-text-direction-language-tag","pass", ,"For the MultiLanguage Map, TD Consumers MAY infer the [=base direction=] from the language tag of the individual strings."
 "thing-model-td-generation-processor-extends","null", ,"If used"
 "thing-model-td-generation-processor-forms","null", ,"Missing communication and/or security metadata details MUST be completed in the Thing Description instance based on Section and/or ."
 "thing-model-td-generation-processor-imports","null", ,"Copy all definitions from the input Thing Model to the resulting Partial TD instance. If used, the extension and imports feature MUST be resolved and represented in the Partial TD instance according to ."


### PR DESCRIPTION
This is now done in playground

An example TD [here](http://plugfest.thingweb.io/playground/#C4EwVgzg9gdg3gKAAQqQIgJYjQLnQVwCcYcIMBbABwBsBTAdQ2AAsARWgMwEN9rgI0AGmSo0AAQDGsYLQAewXEgDaI1KObBglCDgD0ugO5GAdAYDMxqIQDmugEwAGO3cNRgu0LoBuARmM+0VSQAXWE1NGAmOkU0QBYwQCkwQEIwJHjAOjBAVjBAMTB4lMAhMHjAZjAkQHowQEYwQBowQEowJEByMEARMEBaMFKa0sqhILQQWggJQgxKSNgYhOT4-KKyqtrG5takQAkwFMAOMEBxMFKkBvrAKjAV9vCunr6BjFgBPEQ1cNoYXDRoclokalhrJBl5J4wAa0eWDAgkFwYCA3swuAowpcUGguIRbiM8oUShVqvUmi1qot4qt1ps6js0EgggBfSHQiC0CREJgAT3YHAwMCYJxgZyQFyh6AARlwyBIAPo9RQczmiHrMWgPGI8vl7UWiRkxCVcLpwoJqYkksnoClUvrAGmKFSitAyjACoVBUIdSiEKCUWiESLdYXqsXAcH4Nki+URGkOmIQYB9GDWOXy9CEWgqgDyMGohrwwfwtG1JoM+tocYTim41Apac5aCgXIphC8XC50TweYLbqhaA4VnIbONEcuPvblzQzCjHCVmm0el05Bp1C4VGMcgnNFoxik5F0Qc9AkLXeh9piUZVtvtjoN4fX4SkMBkp4AKv7aDEuJQaObwSzdJAhvX5Zqu8E3x-UKSOlwJEGVlXRNYAoGsaxq3ZN9wggLgOGvGsuHzVMYIVLoqDca4FCQlC127JtCBbI00KhTsj3QXtOAHLQdH0Udx0nacqDoecoEXMCIOifCu2LSgYkZLwoB+ACgMPCj0BPM9gEvAM8BhO9qAfIDn2gG5SMuH8Iy-UUtKQP8ri8bDvTfYsjMIZVIlDED206cEuBso8-TknVg0ZMMeKLbcQGzRM3kIFNPIbDMmCzeM-NrWgNIM2zCOIvA2yPcinKo-t5I0WjhwYmcp1kGdWIXXQoGYcSKL4wN8FLXoMC5WhaCM09SqciBKt3MCpGoGJnlDSgoGoTqgt9KTsNkxD0Fve8JEfWBVNfCS9NFHTOT0zViSAA) can be visualized and the text is put the correct direction and truncated correctly.