### PR TITLE
Update manual.csv for logilab TDD

### DIFF
--- a/data/input_2022/TD/siemens-logilab/manual.csv
+++ b/data/input_2022/TD/siemens-logilab/manual.csv
@@ -60,7 +60,7 @@
 "privacy-id-metadata","null",
 "privacy-mutable-identifiers","null",
 "privacy-td-pii","null",
-"privacy-temp-id-metadata","null",
+"privacy-temp-id-metadata","pass",
 "sec-body-name-json-pointer","null",
 "sec-body-name-json-pointer-array","null",
 "sec-body-name-json-pointer-creatable","null",

--- a/data/input_2022/TD/siemens-logilab/manual.csv
+++ b/data/input_2022/TD/siemens-logilab/manual.csv
@@ -69,7 +69,7 @@
 "sec-inj-sanitize","null",
 "sec-vuln-auto","null",
 "security-context-secure-fetch","null",
-"security-jsonld-expansion","null",
+"security-jsonld-expansion","pass",
 "security-mutual-auth-td","null",
 "security-no-execution","null",
 "security-oauth-limits","null",


### PR DESCRIPTION
memory: It is pass since Node.js has inherent memory limit
id: pass since it is required for all TDDs