### PR TITLE
Update node-wot.csv to include TuyaBearerTokens and mixed direction

### DIFF
--- a/data/input_2022/TD/node-wot/node-wot.csv
+++ b/data/input_2022/TD/node-wot/node-wot.csv
@@ -77,7 +77,7 @@
 "td-default-AdditionalResponseContentType", "not-impl", , "AdditionalExpectedResponse contentType value of the contentType of the Form element it belongs to."
 "td-default-observable", "pass", , "PropertyAffordance observable false"
 "td-security-combo-deprecation", "not-impl", , "However, the use of an array with multiple elements to combine security schemes in a security element is now deprecated, instead a ComboSecurityScheme SHOULD be used."
-"td-security-extension", "not-impl", , "Additional security schemes MUST be Subclasses of the Class SecurityScheme."
+"td-security-extension", "pass", , "Additional security schemes MUST be Subclasses of the Class SecurityScheme."
 "td-security-in-uri-variable", "not-impl", , "The URIs provided in interactions where a security scheme using uri as the value for in MUST be a URI template including the defined variable."
 "td-security-uri-variables-distinct", "not-impl", , "The names of URI variables declared in a SecurityScheme MUST be distinct from all other URI variables declared in the TD."
 "td-text-at-direction", "null", , "Given that the Thing Description format is based on JSON-LD 1.1 [[?json-ld11]]"

--- a/data/input_2022/TD/node-wot/node-wot.csv
+++ b/data/input_2022/TD/node-wot/node-wot.csv
@@ -10,6 +10,7 @@
 "server-data-schema-extras", "pass", , "A Thing MAY return additional data from an interaction even when such data is not described in the data schemas given in its WoT Thing Description."
 "server-uri-template", "pass", , "URI Templates, base URIs, and href members in a WoT Thing Description MUST accurately describe the WoT Interface of the Thing."
 "td-context-default-language-direction-independence", "null", , "However, when interpreting human-readable text, each human-readable string value MUST be processed independently."
+"td-producer-mixed-direction","pass", , "TD producers SHOULD attempt to provide mixed direction strings in a way that can be displayed successfully by a naive user agent."
 "td-default-alg", "null", , "The value associated with member alg if not given MUST be assumed to have the default value ES256."
 "td-default-contentType", "pass", , "The value associated with member contentType if not given MUST be assumed to have the default value application/json."
 "td-default-format", "null", , "The value associated with member format if not given MUST be assumed to have the default value jwt."


### PR DESCRIPTION
One assertion is done via the Tuya Bearer Token implementation

https://github.com/eclipse/thingweb.node-wot/blob/master/packages/binding-http/src/http.ts#L56

The mixed direction works well when a TD with a mixed direction is put in the produce() method