### PR TITLE
Calculate a number of at-risk features automatically (for Discovery)

### DIFF
--- a/.github/workflows/discovery-coverage.yml
+++ b/.github/workflows/discovery-coverage.yml
@@ -1,0 +1,30 @@
+name: Discovery coverage report
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'data/input_2022/Discovery/Results/*.csv'
+
+jobs:
+  discovery-coverage-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out wot-testing
+        uses: actions/checkout@v3
+
+      - name: Check out wot-discovery
+        uses: actions/checkout@v3
+        with:
+          repository: w3c/wot-discovery
+          path: wot-discovery
+
+      - name: Run assertion coverage check script
+        run: |
+          python3 data/input_2022/scripts/discovery-coverage.py > ./output.txt
+      
+      - name: Post comment to the PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} -F ./output.txt --repo ${{ github.repository }}

--- a/data/input_2022/scripts/discovery-coverage.py
+++ b/data/input_2022/scripts/discovery-coverage.py
@@ -1,0 +1,36 @@
+import csv
+import os
+
+assertion_id = dict()
+
+with open('wot-discovery/testing/template.csv', 'r') as file:
+    reader = csv.reader(file)
+    for row in reader:
+        if (row[1]!="ID"):
+            assertion_id[row[1]]=0
+
+resdir = "data/input_2022/Discovery/Results"
+csvs = [f for f in os.listdir(resdir) if os.path.isfile(resdir+"/"+f) & f.endswith(".csv")]
+
+for f in csvs:
+    with open(resdir+"/"+f) as file:
+        reader = csv.reader(file)
+        for row in reader:
+            if (row[0]!="ID") & (row[1] == "pass") & (row[0] in assertion_id):
+                assertion_id[row[0]] += 1
+
+covered = 0
+for a in assertion_id:
+    if assertion_id[a] >= 2:
+        covered += 1
+
+print(f'### Discovery spec assertion coverage report')
+print(f'- coverage: {100*covered/len(assertion_id):.2f}%')
+print(f'- at-risk assertions: {len(assertion_id)-covered}')
+print(f'<details>')
+print(f'  <summary>list of at-risk assertions</summary>')
+print(f'')
+for x in assertion_id:
+    if assertion_id[x] < 2:
+        print(f'  - [{x}](https://w3c.github.io/wot-discovery#{x}): pass={assertion_id[x]}')
+print(f'</details>')


### PR DESCRIPTION
I've created GitHub actions to calculate and comment the number of at-risk 
assertions in Discovery spec when a pull-request is made.
It assumes that all the reports in `data/input_2022/Discovery/Results` are independent implementations so that it can use simple counting algorithm.

It could be applied to other specs as well, I think.

![image](https://user-images.githubusercontent.com/30313213/207578061-8c4524b4-8b66-4a60-b386-54dfbedbf7a5.png)
([an example of pull request and comments](https://github.com/k-toumura/wot-testing/pull/1))