### PR TITLE
Update size2 discovery result for node-wot

### DIFF
--- a/data/input_2022/Discovery/node-wot/manual.csv
+++ b/data/input_2022/Discovery/node-wot/manual.csv
@@ -19,7 +19,7 @@
 "exploration-server-coap-alternate-content","pass",
 "exploration-server-coap-method","pass",
 "exploration-server-coap-resp","pass",
-"exploration-server-coap-size2","null",
+"exploration-server-coap-size2","pass",
 "exploration-server-http-alternate-content","null",
 "exploration-server-http-alternate-language","null",
 "exploration-server-http-head","null",


### PR DESCRIPTION
Since node-coap supports the `Size2` option in the meantime, the respective discovery test result can also be changed to `pass` for node-wot. https://github.com/eclipse/thingweb.node-wot/pull/846 updated the dependency and added a corresponding test.