### PR TITLE
Add write permission to the GitHub action workflow

### DIFF
--- a/.github/workflows/discovery-coverage.yml
+++ b/.github/workflows/discovery-coverage.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   discovery-coverage-report:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Check out wot-testing


### PR DESCRIPTION
https://github.com/w3c/wot-testing/pull/507#issuecomment-1351588327
> Merging, although coverage report failed (seemed it could not access a resource; perhaps a deleted file problem?)

This PR may fix the problem.