### PR TITLE
Update architecture test results for dart_wot

### DIFF
--- a/data/input_2022/Architecture/Results/dart_wot.csv
+++ b/data/input_2022/Architecture/Results/dart_wot.csv
@@ -36,7 +36,7 @@
 "arch-rel-types","null",
 "arch-schema","null",
 "arch-security-consideration-auth-private-data","pass",
-"arch-security-consideration-avoid-direct","not-impl","dart_wot can only be used as a consumer and discoverer at the moment"
+"arch-security-consideration-avoid-direct","pass",
 "arch-security-consideration-communication-binding","null",
 "arch-security-consideration-communication-platform","null",
 "arch-security-consideration-dtls-1-2","pass",


### PR DESCRIPTION
As pointed out by @egekorkan in https://github.com/w3c/wot-architecture/issues/888, the architecture assertion [34: arch-security-consideration-avoid-direct](https://w3c.github.io/wot-architecture#arch-security-consideration-avoid-direct) can actually be changed to `pass` for dart_wot. This PR updates the test results accordingly.