### PR TITLE
Mark HTTP content negotiation as pass for node-wot

### DIFF
--- a/data/input_2022/Discovery/node-wot/manual.csv
+++ b/data/input_2022/Discovery/node-wot/manual.csv
@@ -20,7 +20,7 @@
 "exploration-server-coap-method","pass",
 "exploration-server-coap-resp","pass",
 "exploration-server-coap-size2","pass",
-"exploration-server-http-alternate-content","null",
+"exploration-server-http-alternate-content","pass",
 "exploration-server-http-alternate-language","null",
 "exploration-server-http-head","null",
 "exploration-server-http-method","pass",


### PR DESCRIPTION
https://github.com/eclipse/thingweb.node-wot/pull/896 implemented the Discovery feature [41: exploration-server-http-alternate-content](https://w3c.github.io/wot-discovery#exploration-server-http-alternate-content) in node-wot. This PR marks the respective test result as "pass".