### PR TITLE
Update manual.csv

### DIFF
--- a/data/input_2022/Discovery/wothive/manual.csv
+++ b/data/input_2022/Discovery/wothive/manual.csv
@@ -83,7 +83,7 @@
 "tdd-things-create-known-contenttype","pass",
 "tdd-things-update-contenttype","pass",
 "tdd-things-list-pagination","pass",
-"tdd-things-list-pagination-collection","not-impl",
+"tdd-things-list-pagination-collection","pass",
 "tdd-things-list-pagination-header-canonicallink","pass",
 "tdd-things-list-pagination-header-nextlink","pass",
 "tdd-things-list-pagination-header-nextlink-attr","pass",


### PR DESCRIPTION
The feature associated to assertion [tdd-things-list-pagination-collection](https://w3c.github.io/wot-discovery#tdd-things-list-pagination-collection) has been included in the implementation wothive. Is it ok to add it to this file or should I create a folder for 2023 results?