### PR TITLE
Remove authorization key from client flow

### DIFF
--- a/data/input_2022/TD/wot-experimental/TDs/oauth2-garden-thing.td.jsonld
+++ b/data/input_2022/TD/wot-experimental/TDs/oauth2-garden-thing.td.jsonld
@@ -160,7 +160,6 @@
         "oauth2_sc": {
             "scheme": "oauth2",
             "flow": "client",
-            "authorization": "https://dev-23486491.okta.com/oauth2/aus7cc6uibKmmp8GL5d7",
             "in": "header",
             "name": "authorization"
         }


### PR DESCRIPTION
This was a mistake in our Thing implementation since the TD spec says:

> For the client flow authorization MUST NOT be included.

and we were actually checking for that in playground