### PR TITLE
Use Job summary instead of PR Comment for discovery-coverage-report

### DIFF
--- a/.github/workflows/discovery-coverage.yml
+++ b/.github/workflows/discovery-coverage.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   discovery-coverage-report:
     permissions:
+      checks: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/discovery-coverage.yml
+++ b/.github/workflows/discovery-coverage.yml
@@ -8,8 +8,6 @@ on:
 
 jobs:
   discovery-coverage-report:
-    permissions:
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Check out wot-testing
@@ -23,10 +21,4 @@ jobs:
 
       - name: Run assertion coverage check script
         run: |
-          python3 data/input_2022/scripts/discovery-coverage.py > ./output.txt
-      
-      - name: Post comment to the PR
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr comment ${{ github.event.pull_request.number }} -F ./output.txt --repo ${{ github.repository }}
+          python3 data/input_2022/scripts/discovery-coverage.py >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/discovery-coverage.yml
+++ b/.github/workflows/discovery-coverage.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   discovery-coverage-report:
     permissions:
-      checks: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/discovery-coverage.yml
+++ b/.github/workflows/discovery-coverage.yml
@@ -30,4 +30,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr comment ${{ github.event.pull_request.number }} -F ./output.txt
+          gh pr comment ${{ github.event.pull_request.number }} -F ./output.txt --repo ${{ github.repository }}

--- a/.github/workflows/discovery-coverage.yml
+++ b/.github/workflows/discovery-coverage.yml
@@ -29,4 +29,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr comment ${{ github.event.pull_request.number }} -F ./output.txt --repo ${{ github.repository }}
+          gh pr comment ${{ github.event.pull_request.number }} -F ./output.txt


### PR DESCRIPTION
Due to security reason, it is difficult to post comments triggered by a pull request from a forked repository.
This PR made it possible to refer to coverage report as a Job Summary of Actions. 

![image](https://user-images.githubusercontent.com/30313213/225524317-863d48d5-3642-4556-b2bc-df14e7172dd8.png)
