### PR TITLE
Add security assertions for saywot

### DIFF
--- a/data/input_2022/TD/saywot/saywot.csv
+++ b/data/input_2022/TD/saywot/saywot.csv
@@ -60,6 +60,8 @@ td-security-binding,pass
 td-security-in-query-over-uri,not-impl
 td-security-no-extras,pass
 td-security-no-secrets,pass
+security-mutual-auth-td,pass
+security-oauth-limits,pass
 td-vocabulary-defaults,pass
 tm-overwrite-interaction,not-impl
 tm-overwrite-types,not-impl


### PR DESCRIPTION
these two assertions are implemented in saywot! from Siemens. Regarding token limits, there are deployments where this happens and saywot! tries to renew tokens when they expire but saywot! is not the auth server itself. I think this is one of the assertions that are about deployments more than WoT implementations and it is not really saywot! implementing it but this still shows the implementability of the assertion.