### PR TITLE
Fix Size2 result for RIOT implementation

### DIFF
--- a/data/input_2022/Discovery/Results/riot-wot.csv
+++ b/data/input_2022/Discovery/Results/riot-wot.csv
@@ -16,7 +16,7 @@
 "exploration-server-coap-alternate-content","pass",
 "exploration-server-coap-method","pass",
 "exploration-server-coap-resp","pass",
-"exploration-server-coap-size2","fail",
+"exploration-server-coap-size2","pass",
 "sec-tdd-intro-no-observe","pass",
 "sec-tdd-intro-limit-response-size","null",
 "introduction-core-rd","pass",


### PR DESCRIPTION
Thanks to @egekorkan, I noticed that the CoAP Size2 assertion result for the RIOT WoT implementation had not been updated yet. This PR changes the respective result from `fail` to `pass`, which should also make this assertion fully covered implementation-wise.