### PR TITLE
Update Hitachi's results on DID context

### DIFF
--- a/data/input_2022/Discovery/Results/hitachi-esp-idf.csv
+++ b/data/input_2022/Discovery/Results/hitachi-esp-idf.csv
@@ -21,6 +21,7 @@
 "introduction-core-rd-resource-type-directory","not-impl",
 "introduction-core-rd-resource-type-thing","not-impl",
 "introduction-did","pass",
+"introduction-did-service-context","pass",
 "introduction-did-service-endpoint","pass",
 "introduction-direct-directory-description","null",
 "introduction-direct-thing-description","pass",

--- a/data/input_2022/Discovery/Results/hitachi-node-red.csv
+++ b/data/input_2022/Discovery/Results/hitachi-node-red.csv
@@ -21,6 +21,7 @@
 "introduction-core-rd-resource-type-directory","not-impl",
 "introduction-core-rd-resource-type-thing","not-impl",
 "introduction-did","pass",
+"introduction-did-service-context","pass",
 "introduction-did-service-endpoint","pass",
 "introduction-direct-directory-description","null",
 "introduction-direct-thing-description","pass",

--- a/data/input_2022/Discovery/hitachi-esp-idf/manual.csv
+++ b/data/input_2022/Discovery/hitachi-esp-idf/manual.csv
@@ -21,6 +21,7 @@
 "introduction-core-rd-resource-type-directory","not-impl",
 "introduction-core-rd-resource-type-thing","not-impl",
 "introduction-did","pass",
+"introduction-did-service-context","pass",
 "introduction-did-service-endpoint","pass",
 "introduction-direct-directory-description","null",
 "introduction-direct-thing-description","pass",

--- a/data/input_2022/Discovery/hitachi-node-red/manual.csv
+++ b/data/input_2022/Discovery/hitachi-node-red/manual.csv
@@ -21,6 +21,7 @@
 "introduction-core-rd-resource-type-directory","not-impl",
 "introduction-core-rd-resource-type-thing","not-impl",
 "introduction-did","pass",
+"introduction-did-service-context","pass",
 "introduction-did-service-endpoint","pass",
 "introduction-direct-directory-description","null",
 "introduction-direct-thing-description","pass",


### PR DESCRIPTION
Update result on `@context` in DID document (`introduction-did-service-context`).


```
% didkit did-resolve did:web:k-toumura.github.io:didwebtest:led
{
  "@context": [
    "https://www.w3.org/ns/did/v1",
    "https://www.w3.org/2022/wot/discovery-did",  <-- Updated
    {
      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
      "publicKeyJwk": {
        "@id": "https://w3id.org/security#publicKeyJwk",
        "@type": "@json"
      }
    }
   ....
```