### PR TITLE
WoT Week: Add dart_wot app to list of consumers

### DIFF
--- a/events/2024.11.Munich/Readme.md
+++ b/events/2024.11.Munich/Readme.md
@@ -39,7 +39,7 @@ Stakeholders from related SDOs are welcome to contribute.
 | TU Munich    | Hololens                                      |  x       |        |         | HTTP               | Wifi                                                               | no sec should be used; QR code to TD is needed      |   tbc |
 | UC Dublins   | ASTRA/MAMS Platform                           |  X       |        |         |                    |                                                                    |  Multi agent system platform (only software)        | https://github.com/RemCollier |
 | Uni St. Gallen |  YggDrasil                                  |          |        |  X      | HTTP               | ...                                                                |  ...                                                | https://github.com/jeremylemee |
-| Invited Experts | Cross-platform app (using `dart_wot`)      | x        |        |  X      | HTTP, CoAP, MQTT   | WiFi                                                               |  ...                                                | @JKRhb |
+| Eclipse Thingweb | Cross-platform app (using `dart_wot`)      | x        |        |  X      | HTTP, CoAP, MQTT   | WiFi                                                               |  ...                                                | @JKRhb |
 | ...          |     ...                                       |          |        |         |                    | ...                                                                |  ...                                                |   tbc |
 
 Notes: 

--- a/events/2024.11.Munich/Readme.md
+++ b/events/2024.11.Munich/Readme.md
@@ -39,6 +39,7 @@ Stakeholders from related SDOs are welcome to contribute.
 | TU Munich    | Hololens                                      |  x       |        |         | HTTP               | Wifi                                                               | no sec should be used; QR code to TD is needed      |   tbc |
 | UC Dublins   | ASTRA/MAMS Platform                           |  X       |        |         |                    |                                                                    |  Multi agent system platform (only software)        | https://github.com/RemCollier |
 | Uni St. Gallen |  YggDrasil                                  |          |        |  X      | HTTP               | ...                                                                |  ...                                                | https://github.com/jeremylemee |
+| Invited Experts | Cross-platform app (using `dart_wot`)      | x        |        |  X      | HTTP, CoAP, MQTT   | WiFi                                                               |  ...                                                | @JKRhb |
 | ...          |     ...                                       |          |        |         |                    | ...                                                                |  ...                                                |   tbc |
 
 Notes: 


### PR DESCRIPTION
This PR adds a cross-platform application based on [`dart_wot`](https://github.com/eclipse-thingweb/dart_wot) from the Eclipse Thingweb project to the list of potential consumers for the WoT Week in Munich. 